### PR TITLE
Add OP_CHECKLOCKTIMEVERIFY and RPC commands to create cltv address and spend coins from it

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1251,7 +1251,7 @@ static const CRPCCommand vRPCCommands[] =
     { "sendfrom",               &sendfrom,               false,  false },
     { "sendmany",               &sendmany,               false,  false },
     { "addmultisigaddress",     &addmultisigaddress,     false,  false },
-	{ "addcltvaddress",     	&addcltvaddress,	     false,  false },
+	{ "createcltvaddress",     	&createcltvaddress,	     false,  false },
 	{ "spendcltv",     			&spendcltv,	     		 false,  false },
     { "addredeemscript",        &addredeemscript,        false,  false },
     { "getrawmempool",          &getrawmempool,          true,   false },
@@ -1379,7 +1379,7 @@ Array RPCConvertValues(std::string &strMethod, const std::vector<std::string> &s
     if (strMethod == "reservebalance"         && n > 1) ConvertTo<double>(params[1]);
     if (strMethod == "addmultisigaddress"     && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "addmultisigaddress"     && n > 1) ConvertTo<Array>(params[1]);
-    if (strMethod == "addcltvaddress"         && n > 1) ConvertTo<boost::int64_t>(params[1]);
+    if (strMethod == "createcltvaddress"      && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "spendcltv"         	  && n > 2) ConvertTo<boost::int64_t>(params[2]);
     if (strMethod == "listunspent"            && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "listunspent"            && n > 1) ConvertTo<boost::int64_t>(params[1]);

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1251,6 +1251,7 @@ static const CRPCCommand vRPCCommands[] =
     { "sendfrom",               &sendfrom,               false,  false },
     { "sendmany",               &sendmany,               false,  false },
     { "addmultisigaddress",     &addmultisigaddress,     false,  false },
+	{ "addcltvaddress",     	&addcltvaddress,	     false,  false },
     { "addredeemscript",        &addredeemscript,        false,  false },
     { "getrawmempool",          &getrawmempool,          true,   false },
     { "getblock",               &getblock,               false,  false },

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1381,7 +1381,6 @@ Array RPCConvertValues(std::string &strMethod, const std::vector<std::string> &s
     if (strMethod == "addmultisigaddress"     && n > 1) ConvertTo<Array>(params[1]);
     if (strMethod == "createcltvaddress"      && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "spendcltv"         	  && n > 2) ConvertTo<boost::int64_t>(params[2]);
-    if (strMethod == "spendcltv"              && n > 5) ConvertTo<boost::int64_t>(params[5]);
     if (strMethod == "listunspent"            && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "listunspent"            && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "listunspent"            && n > 2) ConvertTo<Array>(params[2]);

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1378,6 +1378,7 @@ Array RPCConvertValues(std::string &strMethod, const std::vector<std::string> &s
     if (strMethod == "reservebalance"         && n > 1) ConvertTo<double>(params[1]);
     if (strMethod == "addmultisigaddress"     && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "addmultisigaddress"     && n > 1) ConvertTo<Array>(params[1]);
+    if (strMethod == "addcltvaddress"         && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "listunspent"            && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "listunspent"            && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "listunspent"            && n > 2) ConvertTo<Array>(params[2]);

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1381,7 +1381,7 @@ Array RPCConvertValues(std::string &strMethod, const std::vector<std::string> &s
     if (strMethod == "addmultisigaddress"     && n > 1) ConvertTo<Array>(params[1]);
     if (strMethod == "createcltvaddress"      && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "spendcltv"         	  && n > 2) ConvertTo<boost::int64_t>(params[2]);
-    if (strMethod == "spendcltv"              && n > 6) ConvertTo<boost::int64_t>(params[6]);
+    if (strMethod == "spendcltv"              && n > 5) ConvertTo<boost::int64_t>(params[5]);
     if (strMethod == "listunspent"            && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "listunspent"            && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "listunspent"            && n > 2) ConvertTo<Array>(params[2]);

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1381,6 +1381,7 @@ Array RPCConvertValues(std::string &strMethod, const std::vector<std::string> &s
     if (strMethod == "addmultisigaddress"     && n > 1) ConvertTo<Array>(params[1]);
     if (strMethod == "createcltvaddress"      && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "spendcltv"         	  && n > 2) ConvertTo<boost::int64_t>(params[2]);
+    if (strMethod == "spendcltv"              && n > 6) ConvertTo<boost::int64_t>(params[6]);
     if (strMethod == "listunspent"            && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "listunspent"            && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "listunspent"            && n > 2) ConvertTo<Array>(params[2]);

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1252,6 +1252,7 @@ static const CRPCCommand vRPCCommands[] =
     { "sendmany",               &sendmany,               false,  false },
     { "addmultisigaddress",     &addmultisigaddress,     false,  false },
 	{ "addcltvaddress",     	&addcltvaddress,	     false,  false },
+	{ "spendcltv",     			&spendcltv,	     		 false,  false },
     { "addredeemscript",        &addredeemscript,        false,  false },
     { "getrawmempool",          &getrawmempool,          true,   false },
     { "getblock",               &getblock,               false,  false },
@@ -1379,6 +1380,7 @@ Array RPCConvertValues(std::string &strMethod, const std::vector<std::string> &s
     if (strMethod == "addmultisigaddress"     && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "addmultisigaddress"     && n > 1) ConvertTo<Array>(params[1]);
     if (strMethod == "addcltvaddress"         && n > 1) ConvertTo<boost::int64_t>(params[1]);
+    if (strMethod == "spendcltv"         	  && n > 2) ConvertTo<boost::int64_t>(params[2]);
     if (strMethod == "listunspent"            && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "listunspent"            && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "listunspent"            && n > 2) ConvertTo<Array>(params[2]);

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -189,6 +189,7 @@ extern json_spirit::Value movecmd(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value sendfrom(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value sendmany(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value addmultisigaddress(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value addcltvaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value addredeemscript(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listreceivedbyaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listreceivedbyaccount(const json_spirit::Array& params, bool fHelp);

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -189,7 +189,7 @@ extern json_spirit::Value movecmd(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value sendfrom(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value sendmany(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value addmultisigaddress(const json_spirit::Array& params, bool fHelp);
-extern json_spirit::Value addcltvaddress(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value createcltvaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value spendcltv(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value addredeemscript(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listreceivedbyaddress(const json_spirit::Array& params, bool fHelp);

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -190,6 +190,7 @@ extern json_spirit::Value sendfrom(const json_spirit::Array& params, bool fHelp)
 extern json_spirit::Value sendmany(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value addmultisigaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value addcltvaddress(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value spendcltv(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value addredeemscript(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listreceivedbyaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listreceivedbyaccount(const json_spirit::Array& params, bool fHelp);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4371,7 +4371,7 @@ bool LoadBlockIndex(bool fAllowNew)
             CScript()           // what is being constructed here?????
             << (!fTestNet?  486604799:      // is this a time? 1985?
                             1464032600)  // how about a more current time????  If it is a time???????
-            << CBigNum(9999)    // what is this??
+            << CScriptNum(9999)    // what is this??
             << vector<unsigned char>((const unsigned char*)pszTimestamp, 
                                      (const unsigned char*)pszTimestamp + strlen(pszTimestamp)
                                     );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -775,6 +775,12 @@ bool CTxMemPool::accept(CTxDB& txdb, CTransaction &tx, bool fCheckInputs,
     if (!fTestNet && !tx.IsStandard(strNonStd))
         return error("CTxMemPool::accept() : nonstandard transaction (%s)", strNonStd.c_str());
 
+    // Only accept nLockTime-using transactions that can be mined in the next
+    // block; we don't want our mempool filled up with transactions that can't
+    // be mined yet.
+    if (!tx.IsFinal())
+        return error("CTxMemPool::accept() : non-final transaction");
+
     // Do we already have it?
     uint256 hash = tx.GetHash();
     {

--- a/src/main.h
+++ b/src/main.h
@@ -600,7 +600,7 @@ public:
         if (nLockTime == 0)
             return true;
         if (nBlockHeight == 0)
-            nBlockHeight = nBestHeight;
+            nBlockHeight = nBestHeight + 1;
         if (nBlockTime == 0)
             nBlockTime = GetAdjustedTime();
         if ((::int64_t)nLockTime < ((::int64_t)nLockTime < LOCKTIME_THRESHOLD ? (::int64_t)nBlockHeight : nBlockTime))

--- a/src/main.h
+++ b/src/main.h
@@ -90,8 +90,6 @@ static const int
 //    CURRENT_VERSION_previous = VERSION_of_block_for_yac_044_old;
 
 inline bool MoneyRange(::int64_t nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
-// Threshold for nLockTime: below this value it is interpreted as block number, otherwise as UNIX timestamp.
-static const unsigned int LOCKTIME_THRESHOLD = 500000000; // Tue Nov  5 00:53:20 1985 UTC
 // Maximum number of script-checking threads allowed
 static const int MAX_SCRIPTCHECK_THREADS = 16;
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -301,6 +301,7 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake)
             LOCK2(cs_main, mempool.cs);
             CBlockIndex
                 * pindexPrev = pindexBest;
+            const int nHeight = pindexPrev->nHeight + 1;
             CTxDB 
                 txdb("r");
 
@@ -321,7 +322,7 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake)
             {
                 CTransaction& 
                     tx = (*mi).second;
-                if (tx.IsCoinBase() || tx.IsCoinStake() || !tx.IsFinal())
+                if (tx.IsCoinBase() || tx.IsCoinStake() || !tx.IsFinal(nHeight))
                     continue;
 
                 COrphan
@@ -544,6 +545,7 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake)
         LOCK2(cs_main, mempool.cs);
         CBlockIndex
             * pindexPrev = pindexBest;
+        const int nHeight = pindexPrev->nHeight + 1;
         CTxDB 
             txdb("r");
 
@@ -565,7 +567,7 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake)
         {
             CTransaction
                 & tx = (*mi).second;
-            if (tx.IsCoinBase() || tx.IsCoinStake() || !tx.IsFinal())
+            if (tx.IsCoinBase() || tx.IsCoinStake() || !tx.IsFinal(nHeight))
                 continue;
 
             COrphan* porphan = NULL;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -764,7 +764,7 @@ void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& 
     unsigned int 
         nHeight = pindexPrev->nHeight+1; // Height first in coinbase required for block.version=2
 
-    pblock->vtx[0].vin[0].scriptSig = (CScript() << nHeight << CBigNum(nExtraNonce)) + COINBASE_FLAGS;
+    pblock->vtx[0].vin[0].scriptSig = (CScript() << nHeight << CScriptNum(nExtraNonce)) + COINBASE_FLAGS;
     Yassert(pblock->vtx[0].vin[0].scriptSig.size() <= 100);
     pblock->hashMerkleRoot = pblock->BuildMerkleTree();
 }

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -192,7 +192,7 @@ Value listunspent(const Array& params, bool fHelp)
 
     Array results;
     vector<COutput> vecOutputs;
-    pwalletMain->AvailableCoins(vecOutputs, false);
+    pwalletMain->AvailableCoins(vecOutputs, false, NULL, NULL, true);
     BOOST_FOREACH(const COutput& out, vecOutputs)
     {
         if (out.nDepth < nMinDepth || out.nDepth > nMaxDepth)

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -20,6 +20,8 @@
  #include "init.h"
 #endif
 
+#include <sstream>
+
 using namespace json_spirit;
 
 using std::runtime_error;
@@ -993,9 +995,19 @@ Value createcltvaddress(const Array& params, bool fHelp)
 
     CBitcoinAddress address(innerID);
 
+    std::string warnMsg = "Any coins sent to this cltv address will be locked until ";
+    if (nLockTime < LOCKTIME_THRESHOLD)
+    {
+        std::stringstream ss;
+        ss << nLockTime;
+        warnMsg += "block height " + ss.str();
+    }
+    else
+        warnMsg += DateTimeStrFormat(nLockTime);
     Object result;
     result.push_back(Pair("cltv address", address.ToString()));
     result.push_back(Pair("redeemScript", HexStr(inner.begin(), inner.end())));
+    result.push_back(Pair("Warning", warnMsg));
 
     pwalletMain->SetAddressBookName(innerID, strAccount);
     return result;

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -943,6 +943,9 @@ Value spendcltv(const Array& params, bool fHelp)
     if (pwalletMain->IsLocked())
         throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please enter the wallet passphrase with walletpassphrase first.");
 
+    // Set current time for nLockTime
+    wtx.nLockTime = GetAdjustedTime();
+
     string strError = pwalletMain->SendMoneyToDestination(destAddress.Get(), nAmount, wtx, false, &scriptPubKey);
     if (strError != "")
         throw JSONRPCError(RPC_WALLET_ERROR, strError);

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -895,7 +895,7 @@ Value addmultisigaddress(const Array& params, bool fHelp)
 
 Value spendcltv(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() != 3)
+	if (fHelp || params.size() < 3 || params.size() > 5)
     {
         string msg = "spendcltv <cltv_address> <destination_address> <amount> [comment] [comment-to]\n"
             "send coin from cltv address to another address\n";
@@ -917,7 +917,7 @@ Value spendcltv(const Array& params, bool fHelp)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid destination address");
 
     // Check if number coins in cltv address is enough to spend
-    int64_t nAmount = params[2].get_int();
+    int64_t nAmount = AmountFromValue(params[2]);
     int64_t nTotalValue = 0;
     for (map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it)
     {

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -895,9 +895,9 @@ Value addmultisigaddress(const Array& params, bool fHelp)
 
 Value spendcltv(const Array& params, bool fHelp)
 {
-	if (fHelp || params.size() < 3 || params.size() > 5)
+    if (fHelp || params.size() < 3 || params.size() > 6)
     {
-        string msg = "spendcltv <cltv_address> <destination_address> <amount> [comment] [comment-to]\n"
+	    string msg = "spendcltv <cltv_address> <destination_address> <amount> [comment] [comment-to] [spending_time]\n"
             "send coin from cltv address to another address\n";
         throw runtime_error(msg);
     }
@@ -944,7 +944,10 @@ Value spendcltv(const Array& params, bool fHelp)
         throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please enter the wallet passphrase with walletpassphrase first.");
 
     // Set current time for nLockTime
-    wtx.nLockTime = GetAdjustedTime();
+    if (params.size() > 5 && params[5].type() != null_type)
+        wtx.nLockTime = params[5].get_int();
+    else
+        wtx.nLockTime = GetAdjustedTime();
 
     string strError = pwalletMain->SendMoneyToDestination(destAddress.Get(), nAmount, wtx, false, &scriptPubKey);
     if (strError != "")

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -941,7 +941,7 @@ Value addcltvaddress(const Array& params, bool fHelp)
     result.push_back(Pair("redeemScript", HexStr(inner.begin(), inner.end())));
 
     pwalletMain->SetAddressBookName(innerID, strAccount);
-    return CBitcoinAddress(innerID).ToString();
+    return result;
 }
 
 Value addredeemscript(const Array& params, bool fHelp)

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1330,6 +1330,7 @@ bool CheckLockTime(const CTransaction& txTo, unsigned int nIn, const CScriptNum&
     // We want to compare apples to apples, so fail the script
     // unless the type of nLockTime being tested is the same as
     // the nLockTime in the transaction.
+    printf("CheckLockTime(), locktime of cltv address = %d, transaction time = %d\n", nLockTime, txTo.nLockTime);
     if (!(
         (txTo.nLockTime <  LOCKTIME_THRESHOLD && nLockTime <  LOCKTIME_THRESHOLD) ||
         (txTo.nLockTime >= LOCKTIME_THRESHOLD && nLockTime >= LOCKTIME_THRESHOLD)
@@ -1339,7 +1340,10 @@ bool CheckLockTime(const CTransaction& txTo, unsigned int nIn, const CScriptNum&
     // Now that we know we're comparing apples-to-apples, the
     // comparison is a simple numeric one.
     if (nLockTime > (int64_t)txTo.nLockTime)
+    {
+        printf("CheckLockTime(), coins are still being locked, can't use them until reaching lock time\n");
         return false;
+    }
 
     // Finally the nLockTime feature can be disabled and thus
     // CHECKLOCKTIMEVERIFY bypassed if every txin has been

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -31,20 +31,10 @@ bool CheckSig(vector<unsigned char> vchSig, const vector<unsigned char> &vchPubK
 static const valtype vchFalse(0);
 static const valtype vchZero(0);
 static const valtype vchTrue(1, 1);
-static const CBigNum bnZero(0);
-static const CBigNum bnOne(1);
-static const CBigNum bnFalse(0);
-static const CBigNum bnTrue(1);
-static const size_t nMaxNumSize = 4;
-
-
-CBigNum CastToBigNum(const valtype& vch)
-{
-    if (vch.size() > nMaxNumSize)
-        throw runtime_error("CastToBigNum() : overflow");
-    // Get rid of extra leading zeros
-    return CBigNum(CBigNum(vch).getvch());
-}
+static const CScriptNum bnZero(0);
+static const CScriptNum bnOne(1);
+static const CScriptNum bnFalse(0);
+static const CScriptNum bnTrue(1);
 
 bool CastToBool(const valtype& vch)
 {
@@ -344,7 +334,6 @@ bool EvalScript(
                 int nHashType
                )
 {
-    CAutoBN_CTX pctx;
     CScript::const_iterator pc = script.begin();
     CScript::const_iterator pend = script.end();
     CScript::const_iterator pbegincodehash = script.begin();
@@ -416,7 +405,7 @@ bool EvalScript(
                 case OP_16:
                 {
                     // ( -- value)
-                    CBigNum bn((int)opcode - (int)(OP_1 - 1));
+                	CScriptNum bn((int)opcode - (int)(OP_1 - 1));
                     stack.push_back(bn.getvch());
                 }
                 break;
@@ -592,7 +581,7 @@ bool EvalScript(
                 case OP_DEPTH:
                 {
                     // -- stacksize
-                    CBigNum bn((::uint16_t) stack.size());
+                	CScriptNum bn(stack.size());
                     stack.push_back(bn.getvch());
                 }
                 break;
@@ -642,7 +631,7 @@ bool EvalScript(
                     // (xn ... x2 x1 x0 n - ... x2 x1 x0 xn)
                     if (stack.size() < 2)
                         return false;
-                    int n = CastToBigNum(stacktop(-1)).getint32();
+                    int n = CScriptNum(stacktop(-1)).getint();
                     popstack(stack);
                     if (n < 0 || n >= (int)stack.size())
                         return false;
@@ -690,7 +679,7 @@ bool EvalScript(
                     // (in -- in size)
                     if (stack.size() < 1)
                         return false;
-                    CBigNum bn((::uint16_t) stacktop(-1).size());
+                    CScriptNum bn(stacktop(-1).size());
                     stack.push_back(bn.getvch());
                 }
                 break;
@@ -741,7 +730,7 @@ bool EvalScript(
                     // (in -- out)
                     if (stack.size() < 1)
                         return false;
-                    CBigNum bn = CastToBigNum(stacktop(-1));
+                    CScriptNum bn(stacktop(-1));
                     switch (opcode)
                     {
                     case OP_1ADD:       bn += bnOne; break;
@@ -776,9 +765,9 @@ bool EvalScript(
                     // (x1 x2 -- out)
                     if (stack.size() < 2)
                         return false;
-                    CBigNum bn1 = CastToBigNum(stacktop(-2));
-                    CBigNum bn2 = CastToBigNum(stacktop(-1));
-                    CBigNum bn;
+                    CScriptNum bn1(stacktop(-2));
+                    CScriptNum bn2(stacktop(-1));
+                    CScriptNum bn(0);
                     switch (opcode)
                     {
                     case OP_ADD:
@@ -823,9 +812,9 @@ bool EvalScript(
                     // (x min max -- out)
                     if (stack.size() < 3)
                         return false;
-                    CBigNum bn1 = CastToBigNum(stacktop(-3));
-                    CBigNum bn2 = CastToBigNum(stacktop(-2));
-                    CBigNum bn3 = CastToBigNum(stacktop(-1));
+                    CScriptNum bn1(stacktop(-3));
+                    CScriptNum bn2(stacktop(-2));
+                    CScriptNum bn3(stacktop(-1));
                     bool fValue = (bn2 <= bn1 && bn1 < bn3);
                     popstack(stack);
                     popstack(stack);
@@ -986,7 +975,7 @@ bool EvalScript(
                     if ((int)stack.size() < i)
                         return false;
 
-                    int nKeysCount = CastToBigNum(stacktop(-i)).getint32();
+                    int nKeysCount = CScriptNum(stacktop(-i)).getint();
                     if (nKeysCount < 0 || nKeysCount > 20)
                         return false;
                     nOpCount += nKeysCount;
@@ -997,7 +986,7 @@ bool EvalScript(
                     if ((int)stack.size() < i)
                         return false;
 
-                    int nSigsCount = CastToBigNum(stacktop(-i)).getint32();
+                    int nSigsCount = CScriptNum(stacktop(-i)).getint();
                     if (nSigsCount < 0 || nSigsCount > nKeysCount)
                         return false;
                     int isig = ++i;

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -27,7 +27,7 @@ using std::map;
 using std::set;
 
 bool CheckSig(vector<unsigned char> vchSig, const vector<unsigned char> &vchPubKey, const CScript &scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType, int flags);
-bool CheckLockTime(const CTransaction& txTo, unsigned int nIn, const CScriptNum& nLockTime) const;
+bool CheckLockTime(const CTransaction& txTo, unsigned int nIn, const CScriptNum& nLockTime);
 
 static const valtype vchFalse(0);
 static const valtype vchZero(0);
@@ -1321,7 +1321,7 @@ public:
     }
 };
 
-bool CheckLockTime(const CTransaction& txTo, unsigned int nIn, const CScriptNum& nLockTime) const
+bool CheckLockTime(const CTransaction& txTo, unsigned int nIn, const CScriptNum& nLockTime)
 {
     // There are two times of nLockTime: lock-by-blockheight
     // and lock-by-blocktime, distinguished by whether

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1700,6 +1700,7 @@ int ScriptSigArgsExpected(txnouttype t, const std::vector<std::vector<unsigned c
         return -1;
     case TX_NULL_DATA:
         return 1;
+    case TX_CLTV:
     case TX_PUBKEY:
         return 1;
     case TX_PUBKEYHASH:

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1467,6 +1467,9 @@ bool Solver(
         // Sender provides N pubkeys, receivers provides M signatures
         mTemplates.insert(make_pair(TX_MULTISIG, CScript() << OP_SMALLINTEGER << OP_PUBKEYS << OP_SMALLINTEGER << OP_CHECKMULTISIG));
 
+        // CLTV transaction, sender provides hash of pubkey, receiver provides redeemscript and signature
+        mTemplates.insert(make_pair(TX_CLTV, CScript() << OP_SMALLDATA << OP_NOP2 << OP_DROP << OP_PUBKEYS << OP_CHECKSIG));
+
         if (!fUseOld044Rules)
         {   // Empty, provably prunable, data-carrying output
             mTemplates.insert(make_pair(TX_NULL_DATA, CScript() << OP_RETURN << OP_SMALLDATA));
@@ -1816,6 +1819,14 @@ isminetype IsMine(const CKeyStore &keystore, const CScript& scriptPubKey)
         if (HaveKeys(keys, keystore) == keys.size())
             return MINE_SPENDABLE;
         break;
+    }
+    case TX_CLTV:
+    {
+       keyID = CPubKey(vSolutions[0]).GetID();
+        if (keystore.HaveKey(keyID))
+        {
+            return MINE_SPENDABLE;
+        }
     }
     }
 

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1668,6 +1668,7 @@ bool Solver(
     case TX_NULL_DATA:  // this is not in 0.4.4 code
         return false;
     case TX_PUBKEY:
+    case TX_CLTV:
         keyID = CPubKey(vSolutions[0]).GetID();
         return Sign1(keyID, keystore, hash, nHashType, scriptSigRet);
     case TX_PUBKEYHASH:
@@ -1995,7 +1996,7 @@ bool SignSignature(const CKeyStore &keystore, const CScript& fromPubKey, CTransa
 
         txnouttype subType;
         bool fSolved =
-            Solver(keystore, subscript, hash2, nHashType, txin.scriptSig, subType) && subType != TX_SCRIPTHASH;
+            Solver(keystore, subscript, hash2, nHashType, txin.scriptSig, subType) && subType != TX_SCRIPTHASH; // IMPORTANT HERE
         // Append serialized subscript whether or not it is completely signed:
         txin.scriptSig << static_cast<valtype>(subscript);
         if (!fSolved) return false;
@@ -2011,7 +2012,7 @@ bool SignSignature(const CKeyStore &keystore, const CTransaction& txFrom, CTrans
     CTxIn& txin = txTo.vin[nIn];
     Yassert(txin.prevout.COutPointGet_n() < txFrom.vout.size());
     Yassert(txin.prevout.COutPointGetHash() == txFrom.GetHash());
-    const CTxOut& txout = txFrom.vout[txin.prevout.COutPointGet_n()];
+    const CTxOut& txout = txFrom.vout[txin.prevout.COutPointGet_n()]; // Get UTXO
 
     return SignSignature(keystore, txout.scriptPubKey, txTo, nIn, nHashType);
 }

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -2251,6 +2251,15 @@ void CScript::SetMultisig(int nRequired, const std::vector<CKey>& keys)
         *this << key.GetPubKey();
     *this << EncodeOP_N((int)(keys.size())) << OP_CHECKMULTISIG;
 }
+
+void CScript::SetCltv(int nLockTime, const CPubKey& pubKey)
+{
+    this->clear();
+
+    *this << nLockTime;
+    *this << OP_CHECKLOCKTIMEVERIFY << OP_DROP;
+	*this << pubKey << OP_CHECKSIG;
+}
 #ifdef _MSC_VER
     #include "msvc_warnings.pop.h"
 #endif

--- a/src/script.h
+++ b/src/script.h
@@ -14,10 +14,6 @@
  #include "keystore.h"
 #endif
 
-#ifndef BITCOIN_BIGNUM_H
- #include "bignum.h"
-#endif
-
 typedef std::vector< ::uint8_t> valtype;
 
 class CTransaction;
@@ -453,7 +449,6 @@ public:
     explicit CScript(opcodetype b)     { operator<<(b); }
     explicit CScript(const uint256& b) { operator<<(b); }
     explicit CScript(const CScriptNum& b) { operator<<(b); }
-    explicit CScript(const CBigNum& b) { operator<<(b); }
     explicit CScript(const std::vector< ::uint8_t>& b) { operator<<(b); }
 
     CScript& operator<<(int64_t b) { return push_int64(b); }
@@ -490,12 +485,6 @@ public:
     {
         std::vector< ::uint8_t> vchKey = key.Raw();
         return (*this) << vchKey;
-    }
-
-    CScript& operator<<(const CBigNum& b)
-    {
-        *this << b.getvch();
-        return *this;
     }
 
     CScript& operator<<(const std::vector< ::uint8_t>& b)

--- a/src/script.h
+++ b/src/script.h
@@ -393,7 +393,7 @@ const char* GetOpName(opcodetype opcode);
 inline std::string ValueString(const std::vector<unsigned char>& vch)
 {
     if (vch.size() <= 4)
-        return strprintf("%d", CBigNum(vch).getint32());
+        return strprintf("%d", CScriptNum(vch).getint());
     else
         return HexStr(vch);
 }
@@ -422,22 +422,7 @@ protected:
         }
         else
         {
-            CBigNum bn(n);
-            *this << bn.getvch();
-        }
-        return *this;
-    }
-
-    CScript& push_uint64(::uint64_t n)
-    {
-        if (n >= 1 && n <= 16)
-        {
-            push_back((::uint8_t)n + (OP_1 - 1));
-        }
-        else
-        {
-            CBigNum bn(n);
-            *this << bn.getvch();
+        	*this << CScriptNum::serialize(n);
         }
         return *this;
     }
@@ -463,30 +448,21 @@ public:
         return ret;
     }
 
-    explicit CScript(::int8_t  b) { operator<<(b); }
-    explicit CScript(::int16_t b) { operator<<(b); }
-    explicit CScript(::int32_t b) { operator<<(b); }
-    explicit CScript(::int64_t b) { operator<<(b); }
-
-    explicit CScript(::uint8_t  b) { operator<<(b); }
-    explicit CScript(::uint16_t b) { operator<<(b); }
-    explicit CScript(::uint32_t b) { operator<<(b); }
-    explicit CScript(::uint64_t b) { operator<<(b); }
+    CScript(int64_t b)        { operator<<(b); }
 
     explicit CScript(opcodetype b)     { operator<<(b); }
     explicit CScript(const uint256& b) { operator<<(b); }
+    explicit CScript(const CScriptNum& b) { operator<<(b); }
     explicit CScript(const CBigNum& b) { operator<<(b); }
     explicit CScript(const std::vector< ::uint8_t>& b) { operator<<(b); }
 
-    CScript& operator<<(::int8_t  b) { return push_int64(b); }
-    CScript& operator<<(::int16_t b) { return push_int64(b); }
-    CScript& operator<<(::int32_t b) { return push_int64(b); }
-    CScript& operator<<(::int64_t b) { return push_int64(b); }
+    CScript& operator<<(int64_t b) { return push_int64(b); }
 
-    CScript& operator<<(::uint8_t  b) { return push_uint64(b); }
-    CScript& operator<<(::uint16_t b) { return push_uint64(b); }
-    CScript& operator<<(::uint32_t b) { return push_uint64(b); }
-    CScript& operator<<(::uint64_t b) { return push_uint64(b); }
+    CScript& operator<<(const CScriptNum& b)
+    {
+        *this << b.getvch();
+        return *this;
+    }
 
     CScript& operator<<(opcodetype opcode)
     {

--- a/src/script.h
+++ b/src/script.h
@@ -742,6 +742,7 @@ int ScriptSigArgsExpected(txnouttype t, const std::vector<std::vector<unsigned c
 bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType);
 isminetype IsMine(const CKeyStore& keystore, const CScript& scriptPubKey);
 isminetype IsMine(const CKeyStore& keystore, const CTxDestination& dest);
+bool IsSpendableCltvUTXO(const CKeyStore &keystore, const CScript& scriptPubKey);
 void ExtractAffectedKeys(const CKeyStore &keystore, const CScript& scriptPubKey, std::vector<CKeyID> &vKeys);
 bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet);
 bool ExtractDestinations(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<CTxDestination>& addressRet, int& nRequiredRet);

--- a/src/script.h
+++ b/src/script.h
@@ -52,7 +52,10 @@ public:
         m_value = n;
     }
 
-    explicit CScriptNum(const std::vector<unsigned char>& vch)
+    static const size_t nDefaultMaxNumSize = 4;
+
+	explicit CScriptNum(const std::vector<unsigned char> &vch,
+			const size_t nMaxNumSize = nDefaultMaxNumSize)
     {
         if (vch.size() > nMaxNumSize)
             throw scriptnum_error("CScriptNum(const std::vector<unsigned char>&) : overflow");
@@ -156,8 +159,6 @@ public:
 
         return result;
     }
-
-    static const size_t nMaxNumSize = 4;
 
 private:
     static int64_t set_vch(const std::vector<unsigned char>& vch)

--- a/src/script.h
+++ b/src/script.h
@@ -202,6 +202,11 @@ enum
     SCRIPT_VERIFY_LOW_S     = (1U << 2), // enforce low S values in signatures (depends on STRICTENC)
     SCRIPT_VERIFY_NOCACHE   = (1U << 3), // do not store results in signature cache (but do query it)
     SCRIPT_VERIFY_NULLDUMMY = (1U << 4), // verify dummy stack item consumed by CHECKMULTISIG is of zero-length
+
+    // Verify CHECKLOCKTIMEVERIFY
+    //
+    // See BIP65 for details.
+    SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY = (1U << 9),
 };
 
 // Strict verification:
@@ -223,7 +228,7 @@ static const unsigned int MANDATORY_SCRIPT_VERIFY_FLAGS = SCRIPT_VERIFY_P2SH;
 // Standard script verification flags that standard transactions will comply
 // with. However scripts violating these flags may still be present in valid
 // blocks and we must accept those blocks.
-static const unsigned int STRICT_FLAGS = MANDATORY_SCRIPT_VERIFY_FLAGS | STRICT_FORMAT_FLAGS;
+static const unsigned int STRICT_FLAGS = MANDATORY_SCRIPT_VERIFY_FLAGS | STRICT_FORMAT_FLAGS | SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
 
 // Soft verifications, no extended signature format checkings
 static const unsigned int SOFT_FLAGS = STRICT_FLAGS & ~STRICT_FORMAT_FLAGS;
@@ -367,6 +372,7 @@ enum opcodetype
     // expansion
     OP_NOP1 = 0xb0,
     OP_NOP2 = 0xb1,
+	OP_CHECKLOCKTIMEVERIFY = OP_NOP2,
     OP_NOP3 = 0xb2,
     OP_NOP4 = 0xb3,
     OP_NOP5 = 0xb4,

--- a/src/script.h
+++ b/src/script.h
@@ -241,6 +241,7 @@ enum txnouttype
     TX_PUBKEYHASH,
     TX_SCRIPTHASH,
     TX_MULTISIG,
+	TX_CLTV,
     TX_NULL_DATA,
 };
 

--- a/src/script.h
+++ b/src/script.h
@@ -690,7 +690,7 @@ public:
 
     void SetDestination(const CTxDestination& address);
     void SetMultisig(int nRequired, const std::vector<CKey>& keys);
-
+    void SetCltv(int nLockTime, const CPubKey& pubKey);
 
     void PrintHex() const
     {

--- a/src/script.h
+++ b/src/script.h
@@ -20,6 +20,9 @@ class CTransaction;
 
 static const unsigned int MAX_SCRIPT_ELEMENT_SIZE = 520; // bytes
 
+// Threshold for nLockTime: below this value it is interpreted as block number, otherwise as UNIX timestamp.
+static const unsigned int LOCKTIME_THRESHOLD = 500000000; // Tue Nov  5 00:53:20 1985 UTC
+
 /** IsMine() return codes */
 enum isminetype
 {

--- a/src/script.h
+++ b/src/script.h
@@ -35,6 +35,155 @@ enum isminetype
 
 typedef ::uint8_t isminefilter;
 
+class scriptnum_error : public std::runtime_error
+{
+public:
+    explicit scriptnum_error(const std::string& str) : std::runtime_error(str) {}
+};
+
+class CScriptNum
+{
+// Numeric opcodes (OP_1ADD, etc) are restricted to operating on 4-byte integers.
+// The semantics are subtle, though: operands must be in the range [-2^31 +1...2^31 -1],
+// but results may overflow (and are valid as long as they are not used in a subsequent
+// numeric operation). CScriptNum enforces those semantics by storing results as
+// an int64 and allowing out-of-range values to be returned as a vector of bytes but
+// throwing an exception if arithmetic is done or the result is interpreted as an integer.
+public:
+
+    explicit CScriptNum(const int64_t& n)
+    {
+        m_value = n;
+    }
+
+    explicit CScriptNum(const std::vector<unsigned char>& vch)
+    {
+        if (vch.size() > nMaxNumSize)
+            throw scriptnum_error("CScriptNum(const std::vector<unsigned char>&) : overflow");
+        m_value = set_vch(vch);
+    }
+
+    inline bool operator==(const int64_t& rhs) const    { return m_value == rhs; }
+    inline bool operator!=(const int64_t& rhs) const    { return m_value != rhs; }
+    inline bool operator<=(const int64_t& rhs) const    { return m_value <= rhs; }
+    inline bool operator< (const int64_t& rhs) const    { return m_value <  rhs; }
+    inline bool operator>=(const int64_t& rhs) const    { return m_value >= rhs; }
+    inline bool operator> (const int64_t& rhs) const    { return m_value >  rhs; }
+
+    inline bool operator==(const CScriptNum& rhs) const { return operator==(rhs.m_value); }
+    inline bool operator!=(const CScriptNum& rhs) const { return operator!=(rhs.m_value); }
+    inline bool operator<=(const CScriptNum& rhs) const { return operator<=(rhs.m_value); }
+    inline bool operator< (const CScriptNum& rhs) const { return operator< (rhs.m_value); }
+    inline bool operator>=(const CScriptNum& rhs) const { return operator>=(rhs.m_value); }
+    inline bool operator> (const CScriptNum& rhs) const { return operator> (rhs.m_value); }
+
+    inline CScriptNum operator+(   const int64_t& rhs)    const { return CScriptNum(m_value + rhs);}
+    inline CScriptNum operator-(   const int64_t& rhs)    const { return CScriptNum(m_value - rhs);}
+    inline CScriptNum operator+(   const CScriptNum& rhs) const { return operator+(rhs.m_value);   }
+    inline CScriptNum operator-(   const CScriptNum& rhs) const { return operator-(rhs.m_value);   }
+
+    inline CScriptNum& operator+=( const CScriptNum& rhs)       { return operator+=(rhs.m_value);  }
+    inline CScriptNum& operator-=( const CScriptNum& rhs)       { return operator-=(rhs.m_value);  }
+
+    inline CScriptNum operator-()                         const
+    {
+        assert(m_value != std::numeric_limits<int64_t>::min());
+        return CScriptNum(-m_value);
+    }
+
+    inline CScriptNum& operator=( const int64_t& rhs)
+    {
+        m_value = rhs;
+        return *this;
+    }
+
+    inline CScriptNum& operator+=( const int64_t& rhs)
+    {
+        assert(rhs == 0 || (rhs > 0 && m_value <= std::numeric_limits<int64_t>::max() - rhs) ||
+                           (rhs < 0 && m_value >= std::numeric_limits<int64_t>::min() - rhs));
+        m_value += rhs;
+        return *this;
+    }
+
+    inline CScriptNum& operator-=( const int64_t& rhs)
+    {
+        assert(rhs == 0 || (rhs > 0 && m_value >= std::numeric_limits<int64_t>::min() + rhs) ||
+                           (rhs < 0 && m_value <= std::numeric_limits<int64_t>::max() + rhs));
+        m_value -= rhs;
+        return *this;
+    }
+
+    int getint() const
+    {
+        if (m_value > std::numeric_limits<int>::max())
+            return std::numeric_limits<int>::max();
+        else if (m_value < std::numeric_limits<int>::min())
+            return std::numeric_limits<int>::min();
+        return m_value;
+    }
+
+    std::vector<unsigned char> getvch() const
+    {
+        return serialize(m_value);
+    }
+
+    static std::vector<unsigned char> serialize(const int64_t& value)
+    {
+        if(value == 0)
+            return std::vector<unsigned char>();
+
+        std::vector<unsigned char> result;
+        const bool neg = value < 0;
+        uint64_t absvalue = neg ? -value : value;
+
+        while(absvalue)
+        {
+            result.push_back(absvalue & 0xff);
+            absvalue >>= 8;
+        }
+
+
+//    - If the most significant byte is >= 0x80 and the value is positive, push a
+//    new zero-byte to make the significant byte < 0x80 again.
+
+//    - If the most significant byte is >= 0x80 and the value is negative, push a
+//    new 0x80 byte that will be popped off when converting to an integral.
+
+//    - If the most significant byte is < 0x80 and the value is negative, add
+//    0x80 to it, since it will be subtracted and interpreted as a negative when
+//    converting to an integral.
+
+        if (result.back() & 0x80)
+            result.push_back(neg ? 0x80 : 0);
+        else if (neg)
+            result.back() |= 0x80;
+
+        return result;
+    }
+
+    static const size_t nMaxNumSize = 4;
+
+private:
+    static int64_t set_vch(const std::vector<unsigned char>& vch)
+    {
+      if (vch.empty())
+          return 0;
+
+      int64_t result = 0;
+      for (size_t i = 0; i != vch.size(); ++i)
+          result |= static_cast<int64_t>(vch[i]) << 8*i;
+
+      // If the input vector's most significant byte is 0x80, remove it from
+      // the result's msb and return a negative.
+      if (vch.back() & 0x80)
+          return -(result & ~(0x80 << (8 * (vch.size() - 1))));
+
+      return result;
+    }
+
+    int64_t m_value;
+};
+
 /** Signature hash types/flags */
 enum
 {

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1505,30 +1505,19 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
 
             for (unsigned int i = 0; i < pcoin->vout.size(); ++i)
             {
-            	// CHECK CLTV ADDRESS WITH VOUT ADDRESS HERE
                 isminetype 
                     mine = IsMine(pcoin->vout[i]);
 
-                if (
-                    !(pcoin->IsSpent(i)) && 
-                    (mine != MINE_NO) && 
-                    (pcoin->vout[i].nValue >= nMinimumInputValue) &&
-                    ( 
-                     (!coinControl) || 
-                     !(coinControl->HasSelected() ) || 
-                     coinControl->IsSelected((*it).first, i)
-                    )
-                   )
-                {
-                    vCoins.push_back(
-                                     COutput(
-                                             pcoin, 
-                                             i, 
-                                             pcoin->GetDepthInMainChain(), 
-                                             mine == MINE_SPENDABLE
-                                            )
-                                    );
-                }
+				if (!(pcoin->IsSpent(i)) && (mine != MINE_NO)
+						&& ((!fromScriptPubKey) || pcoin->vout[i].scriptPubKey == *fromScriptPubKey) // Only use coins in a specific address
+						&& (pcoin->vout[i].nValue >= nMinimumInputValue)
+						&& ((!coinControl) || !(coinControl->HasSelected())
+								|| coinControl->IsSelected((*it).first, i)))
+				{
+					vCoins.push_back(
+							COutput(pcoin, i, pcoin->GetDepthInMainChain(),
+									mine == MINE_SPENDABLE));
+				}
             }
         }
     }

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1481,7 +1481,7 @@ int64_t CWallet::GetImmatureWatchOnlyBalance() const
 }
 
 // populate vCoins with vector of spendable COutputs
-void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const CCoinControl *coinControl, const CScript *fromScriptPubKey) const
+void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const CCoinControl *coinControl, const CScript *fromScriptPubKey, bool fCountCltv) const
 {
     vCoins.clear();
 
@@ -1510,7 +1510,7 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
 				bool isSpendableCltv = IsSpendableCltvUTXO(pcoin->vout[i]);
 
 				if (!(pcoin->IsSpent(i)) && (mine != MINE_NO)
-						&& ((!fromScriptPubKey && !isSpendableCltv) // If not specific address, not select coins from cltv address
+						&& ((!fromScriptPubKey && (fCountCltv || !isSpendableCltv)) // If not specific address, not select coins from cltv address
 								|| (fromScriptPubKey && pcoin->vout[i].scriptPubKey == *fromScriptPubKey)) // If there is a specific address, only select coins in that address
 						&& (pcoin->vout[i].nValue >= nMinimumInputValue)
 						&& ((!coinControl) || !(coinControl->HasSelected())

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1928,7 +1928,16 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> > &vecSend,
 
                 // Fill vin
                 BOOST_FOREACH(const PAIRTYPE(const CWalletTx*,unsigned int)& coin, setCoins)
-                    wtxNew.vin.push_back(CTxIn(coin.first->GetHash(),coin.second));
+                {
+                	// In order nLockTime and OP_CHECKLOCKTIMEVERIFY can work, set nSequence to another value which different with maxint
+                	unsigned int nSequenceIn = std::numeric_limits<unsigned int>::max();
+                	if (IsSpendableCltvUTXO(coin.first->vout[coin.second]))
+                	{
+                		nSequenceIn = 0;
+                	}
+					wtxNew.vin.push_back(
+							CTxIn(coin.first->GetHash(), coin.second, CScript(), nSequenceIn));
+                }
 
                 // Sign
                 int nIn = 0;

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1481,7 +1481,7 @@ int64_t CWallet::GetImmatureWatchOnlyBalance() const
 }
 
 // populate vCoins with vector of spendable COutputs
-void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const CCoinControl *coinControl) const
+void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const CCoinControl *coinControl, const CScript *fromScriptPubKey) const
 {
     vCoins.clear();
 
@@ -1505,6 +1505,7 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
 
             for (unsigned int i = 0; i < pcoin->vout.size(); ++i)
             {
+            	// CHECK CLTV ADDRESS WITH VOUT ADDRESS HERE
                 isminetype 
                     mine = IsMine(pcoin->vout[i]);
 
@@ -1779,11 +1780,14 @@ bool CWallet::SelectCoinsMinConf(int64_t nTargetValue, int64_t nSpendTime, int n
     return true;
 }
 
-bool CWallet::SelectCoins(int64_t nTargetValue, int64_t nSpendTime, set<pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet, const CCoinControl* coinControl) const
+bool CWallet::SelectCoins(int64_t nTargetValue, int64_t nSpendTime,
+		set<pair<const CWalletTx*, unsigned int> > &setCoinsRet,
+		int64_t &nValueRet, const CCoinControl *coinControl,
+		const CScript *fromScriptPubKey) const
 {
     vector<COutput> vCoins;
     
-    AvailableCoins(vCoins, true, coinControl);
+    AvailableCoins(vCoins, true, coinControl, fromScriptPubKey);
 
     // coin control -> return all selected outputs (we want all selected to go into the transaction for sure)
     if (coinControl && coinControl->HasSelected())
@@ -1853,7 +1857,9 @@ bool CWallet::SelectCoinsSimple(int64_t nTargetValue, int64_t nMinValue, int64_t
     return true;
 }
 
-bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, int64_t& nFeeRet, const CCoinControl* coinControl)
+bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> > &vecSend,
+		CWalletTx &wtxNew, CReserveKey &reservekey, int64_t &nFeeRet,
+		const CCoinControl *coinControl, const CScript *fromScriptPubKey)
 {
     int64_t nValue = 0;
     BOOST_FOREACH (const PAIRTYPE(CScript, int64_t)& s, vecSend)
@@ -1887,7 +1893,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend, 
                 // Choose coins to use
                 set<pair<const CWalletTx*,unsigned int> > setCoins;
                 int64_t nValueIn = 0;
-                if (!SelectCoins(nTotalValue, wtxNew.nTime, setCoins, nValueIn, coinControl))
+                if (!SelectCoins(nTotalValue, wtxNew.nTime, setCoins, nValueIn, coinControl, fromScriptPubKey))
                     return false;
                 BOOST_FOREACH(PAIRTYPE(const CWalletTx*, unsigned int) pcoin, setCoins)
                 {
@@ -1980,11 +1986,13 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend, 
     return true;
 }
 
-bool CWallet::CreateTransaction(CScript scriptPubKey, int64_t nValue, CWalletTx& wtxNew, CReserveKey& reservekey, int64_t& nFeeRet, const CCoinControl* coinControl)
+bool CWallet::CreateTransaction(CScript scriptPubKey, int64_t nValue,
+		CWalletTx &wtxNew, CReserveKey &reservekey, int64_t &nFeeRet,
+		const CCoinControl *coinControl, const CScript *fromScriptPubKey)
 {
     vector< pair<CScript, int64_t> > vecSend;
     vecSend.push_back(make_pair(scriptPubKey, nValue));
-    return CreateTransaction(vecSend, wtxNew, reservekey, nFeeRet, coinControl);
+    return CreateTransaction(vecSend, wtxNew, reservekey, nFeeRet, coinControl, fromScriptPubKey);
 }
 
 void CWallet::GetStakeWeightFromValue(const int64_t& nTime, const int64_t& nValue, uint64_t& nWeight)
@@ -2898,7 +2906,7 @@ bool CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey)
 
 
 
-string CWallet::SendMoney(CScript scriptPubKey, int64_t nValue, CWalletTx& wtxNew, bool fAskFee)
+string CWallet::SendMoney(CScript scriptPubKey, int64_t nValue, CWalletTx& wtxNew, bool fAskFee, const CScript* fromScriptPubKey)
 {
     CReserveKey reservekey(this);
     int64_t nFeeRequired;
@@ -2915,7 +2923,7 @@ string CWallet::SendMoney(CScript scriptPubKey, int64_t nValue, CWalletTx& wtxNe
         printf("SendMoney() : %s", strError.c_str());
         return strError;
     }
-    if (!CreateTransaction(scriptPubKey, nValue, wtxNew, reservekey, nFeeRequired))
+    if (!CreateTransaction(scriptPubKey, nValue, wtxNew, reservekey, nFeeRequired, NULL, fromScriptPubKey))
     {
         string strError;
         if (nValue + nFeeRequired > GetBalance())
@@ -2937,7 +2945,7 @@ string CWallet::SendMoney(CScript scriptPubKey, int64_t nValue, CWalletTx& wtxNe
 
 
 
-string CWallet::SendMoneyToDestination(const CTxDestination& address, int64_t nValue, CWalletTx& wtxNew, bool fAskFee)
+string CWallet::SendMoneyToDestination(const CTxDestination& address, int64_t nValue, CWalletTx& wtxNew, bool fAskFee, const CScript* fromScriptPubKey)
 {
     // Check amount
     if (nValue <= 0)
@@ -2949,7 +2957,7 @@ string CWallet::SendMoneyToDestination(const CTxDestination& address, int64_t nV
     CScript scriptPubKey;
     scriptPubKey.SetDestination(address);
 
-    return SendMoney(scriptPubKey, nValue, wtxNew, fAskFee);
+    return SendMoney(scriptPubKey, nValue, wtxNew, fAskFee, fromScriptPubKey);
 }
 
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1505,11 +1505,13 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
 
             for (unsigned int i = 0; i < pcoin->vout.size(); ++i)
             {
-                isminetype 
-                    mine = IsMine(pcoin->vout[i]);
+				isminetype mine = IsMine(pcoin->vout[i]);
+
+				bool isSpendableCltv = IsSpendableCltvUTXO(pcoin->vout[i]);
 
 				if (!(pcoin->IsSpent(i)) && (mine != MINE_NO)
-						&& ((!fromScriptPubKey) || pcoin->vout[i].scriptPubKey == *fromScriptPubKey) // Only use coins in a specific address
+						&& ((!fromScriptPubKey && !isSpendableCltv) // If not specific address, not select coins from cltv address
+								|| (fromScriptPubKey && pcoin->vout[i].scriptPubKey == *fromScriptPubKey)) // If there is a specific address, only select coins in that address
 						&& (pcoin->vout[i].nValue >= nMinimumInputValue)
 						&& ((!coinControl) || !(coinControl->HasSelected())
 								|| coinControl->IsSelected((*it).first, i)))

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -92,8 +92,14 @@ public:
 class CWallet : public CCryptoKeyStore
 {
 private:
-    bool SelectCoinsSimple(::int64_t nTargetValue, ::int64_t nMinValue, ::int64_t nMaxValue, int64_t nSpendTime, int nMinConf, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, ::int64_t& nValueRet) const;
-    bool SelectCoins(::int64_t nTargetValue, int64_t nSpendTime, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, ::int64_t& nValueRet, const CCoinControl *coinControl=NULL) const;
+	bool SelectCoinsSimple(::int64_t nTargetValue, ::int64_t nMinValue,
+			::int64_t nMaxValue, int64_t nSpendTime, int nMinConf,
+			std::set<std::pair<const CWalletTx*, unsigned int> > &setCoinsRet,
+			::int64_t &nValueRet) const;
+	bool SelectCoins(::int64_t nTargetValue, int64_t nSpendTime,
+			std::set<std::pair<const CWalletTx*, unsigned int> > &setCoinsRet,
+			::int64_t &nValueRet, const CCoinControl *coinControl = NULL,
+			const CScript *fromScriptPubKey = NULL) const;
 
     CWalletDB *pwalletdbEncryption, *pwalletdbDecryption;
 
@@ -164,7 +170,7 @@ public:
     bool CanSupportFeature(enum WalletFeature wf) { return nWalletMaxVersion >= wf; }
 
     void AvailableCoinsMinConf(std::vector<COutput>& vCoins, int nConf, ::int64_t nMinValue, ::int64_t nMaxValue) const;
-    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl=NULL) const;
+    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl=NULL, const CScript *fromScriptPubKey=NULL) const;
     bool SelectCoinsMinConf(::int64_t nTargetValue, int64_t nSpendTime, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, ::int64_t& nValueRet) const;
     // keystore implementation
     // Generate a new key
@@ -237,8 +243,15 @@ public:
     ::int64_t GetNewMint() const;
     ::int64_t GetWatchOnlyStake() const;
     ::int64_t GetWatchOnlyNewMint() const;
-    bool CreateTransaction(const std::vector<std::pair<CScript, ::int64_t> >& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, ::int64_t& nFeeRet, const CCoinControl *coinControl=NULL);
-    bool CreateTransaction(CScript scriptPubKey, ::int64_t nValue, CWalletTx& wtxNew, CReserveKey& reservekey, ::int64_t& nFeeRet, const CCoinControl *coinControl=NULL);
+	bool CreateTransaction(
+			const std::vector<std::pair<CScript, ::int64_t> > &vecSend,
+			CWalletTx &wtxNew, CReserveKey &reservekey, ::int64_t &nFeeRet,
+			const CCoinControl *coinControl = NULL,
+			const CScript *fromScriptPubKey = NULL);
+	bool CreateTransaction(CScript scriptPubKey, ::int64_t nValue,
+			CWalletTx &wtxNew, CReserveKey &reservekey, ::int64_t &nFeeRet,
+			const CCoinControl *coinControl = NULL,
+			const CScript *fromScriptPubKey = NULL);
     bool CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey);
 
     void GetStakeStats(float &nKernelsRate, float &nCoinDaysRate);
@@ -258,8 +271,8 @@ public:
                         );
     bool MergeCoins(const ::int64_t& nAmount, const ::int64_t& nMinValue, const ::int64_t& nMaxValue, std::list<uint256>& listMerged);
 
-    std::string SendMoney(CScript scriptPubKey, ::int64_t nValue, CWalletTx& wtxNew, bool fAskFee=false);
-    std::string SendMoneyToDestination(const CTxDestination &address, ::int64_t nValue, CWalletTx& wtxNew, bool fAskFee=false);
+    std::string SendMoney(CScript scriptPubKey, ::int64_t nValue, CWalletTx& wtxNew, bool fAskFee=false, const CScript* fromScriptPubKey=NULL);
+    std::string SendMoneyToDestination(const CTxDestination &address, ::int64_t nValue, CWalletTx& wtxNew, bool fAskFee=false, const CScript* fromScriptPubKey=NULL);
 
     bool NewKeyPool(unsigned int nSize = 0);
     bool TopUpKeyPool(unsigned int nSize = 0);

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -293,6 +293,10 @@ public:
     {
         return ::IsMine(*this, txout.scriptPubKey);
     }
+    bool IsSpendableCltvUTXO(const CTxOut& txout) const
+    {
+        return ::IsSpendableCltvUTXO(*this, txout.scriptPubKey);
+    }
     ::int64_t GetCredit(const CTxOut& txout, const isminefilter& filter) const
     {
         if (!MoneyRange(txout.nValue))

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -170,7 +170,7 @@ public:
     bool CanSupportFeature(enum WalletFeature wf) { return nWalletMaxVersion >= wf; }
 
     void AvailableCoinsMinConf(std::vector<COutput>& vCoins, int nConf, ::int64_t nMinValue, ::int64_t nMaxValue) const;
-    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl=NULL, const CScript *fromScriptPubKey=NULL) const;
+    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl=NULL, const CScript *fromScriptPubKey=NULL, bool fCountCltv=false) const;
     bool SelectCoinsMinConf(::int64_t nTargetValue, int64_t nSpendTime, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, ::int64_t& nValueRet) const;
     // keystore implementation
     // Generate a new key


### PR DESCRIPTION
Hi all,
This PR contains all changes relating to OP_CHECKLOCKTIMEVERIFY and two RPC commands "createcltvaddress", "spendcltv" 

Test scenario, video demo and instruction how to use rpc commands:
 1)  Time-based relative lock-times
Instruction/test scenario: https://trello-attachments.s3.amazonaws.com/5e258c849f74416a02536a94/5e7cffe717e5c073ab54028a/94919767b71b151655365570f632d1af/Instruction_cltv.txt
Demo video: https://drive.google.com/file/d/15sXrP1XmfE2MrW-dzRRxXZkSlYfU142Y/view?usp=sharing

Note: You should download video and watch on your PC, you can use VLC to watch it. Because the default resolution is not good if you watch it directly on google drive.