### PR TITLE
Add OP_CHECKSEQUENCEVERIFY and RPC commands to create csv address and spend coins from it

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1254,6 +1254,7 @@ static const CRPCCommand vRPCCommands[] =
 	{ "createcltvaddress",     	&createcltvaddress,	     false,  false },
 	{ "spendcltv",     			&spendcltv,	     		 false,  false },
 	{ "createcsvaddress",       &createcsvaddress,       false,  false },
+	{ "spendcsv",               &spendcsv,               false,  false },
     { "addredeemscript",        &addredeemscript,        false,  false },
     { "getrawmempool",          &getrawmempool,          true,   false },
     { "getblock",               &getblock,               false,  false },
@@ -1384,6 +1385,7 @@ Array RPCConvertValues(std::string &strMethod, const std::vector<std::string> &s
     if (strMethod == "spendcltv"         	  && n > 2) ConvertTo<boost::int64_t>(params[2]);
     if (strMethod == "createcsvaddress"       && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "createcsvaddress"       && n > 1) ConvertTo<bool>(params[1]);
+    if (strMethod == "spendcsv"               && n > 2) ConvertTo<boost::int64_t>(params[2]);
     if (strMethod == "listunspent"            && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "listunspent"            && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "listunspent"            && n > 2) ConvertTo<Array>(params[2]);

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1253,6 +1253,7 @@ static const CRPCCommand vRPCCommands[] =
     { "addmultisigaddress",     &addmultisigaddress,     false,  false },
 	{ "createcltvaddress",     	&createcltvaddress,	     false,  false },
 	{ "spendcltv",     			&spendcltv,	     		 false,  false },
+	{ "createcsvaddress",       &createcsvaddress,       false,  false },
     { "addredeemscript",        &addredeemscript,        false,  false },
     { "getrawmempool",          &getrawmempool,          true,   false },
     { "getblock",               &getblock,               false,  false },
@@ -1381,6 +1382,8 @@ Array RPCConvertValues(std::string &strMethod, const std::vector<std::string> &s
     if (strMethod == "addmultisigaddress"     && n > 1) ConvertTo<Array>(params[1]);
     if (strMethod == "createcltvaddress"      && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "spendcltv"         	  && n > 2) ConvertTo<boost::int64_t>(params[2]);
+    if (strMethod == "createcsvaddress"       && n > 0) ConvertTo<boost::int64_t>(params[0]);
+    if (strMethod == "createcsvaddress"       && n > 1) ConvertTo<bool>(params[1]);
     if (strMethod == "listunspent"            && n > 0) ConvertTo<boost::int64_t>(params[0]);
     if (strMethod == "listunspent"            && n > 1) ConvertTo<boost::int64_t>(params[1]);
     if (strMethod == "listunspent"            && n > 2) ConvertTo<Array>(params[2]);

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -192,6 +192,7 @@ extern json_spirit::Value addmultisigaddress(const json_spirit::Array& params, b
 extern json_spirit::Value createcltvaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value spendcltv(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value createcsvaddress(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value spendcsv(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value addredeemscript(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listreceivedbyaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listreceivedbyaccount(const json_spirit::Array& params, bool fHelp);

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -191,6 +191,7 @@ extern json_spirit::Value sendmany(const json_spirit::Array& params, bool fHelp)
 extern json_spirit::Value addmultisigaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value createcltvaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value spendcltv(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value createcsvaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value addredeemscript(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listreceivedbyaddress(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listreceivedbyaccount(const json_spirit::Array& params, bool fHelp);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -390,7 +390,7 @@ unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans)
 }
 
 /**
- * Calculates the block height and previous block's median time past at
+ * Calculates the block height and previous block's time at
  * which the transaction will be considered final in the context of BIP 68.
  * Also removes from the vector of input heights any entries which did not
  * correspond to sequence locked inputs as they do not affect the calculation.
@@ -439,8 +439,7 @@ static std::pair<int, int64_t> CalculateSequenceLocks(const CTransaction &tx,
 
             // Time-based relative lock-times are measured from the
             // smallest allowed timestamp of the block containing the
-            // txout being spent, which is the median time past of the
-            // block prior.
+            // txout being spent, which is the time of the block prior.
             nMinTime = std::max(nMinTime, nCoinTime + (int64_t)((txin.nSequence & CTxIn::SEQUENCE_LOCKTIME_MASK) << CTxIn::SEQUENCE_LOCKTIME_GRANULARITY) - 1);
         }
         else
@@ -464,10 +463,10 @@ static bool EvaluateSequenceLocks(const CBlockIndex& block, std::pair<int, int64
     }
     else if (lockPair.second >= nBlockTime)
     {
-        printf("EvaluateSequenceLocks, failed to use relative time-lock coins, current block time  = %ld"
-                ", the coin inputs can only be used after a block with block time > %d was mined\n",
-                DateTimeStrFormat(nBlockTime),
-                DateTimeStrFormat(lockPair.second));
+        printf("EvaluateSequenceLocks, failed to use relative time-lock coins, current block time  = %ld (%s)"
+                ", the coin inputs can only be used after a block with block time > %ld (%s) is mined\n",
+                nBlockTime, DateTimeStrFormat(nBlockTime).c_str(),
+                lockPair.second, DateTimeStrFormat(lockPair.second).c_str());
         return false;
     }
 
@@ -485,12 +484,12 @@ bool CheckSequenceLocks(const CTransaction &tx, int flags)
 
     CBlockIndex index;
     index.pprev = pindexBest;
-    // CheckSequenceLocks() uses chainActive.Height()+1 to evaluate
+    // CheckSequenceLocks() uses pindexBest->nHeight+1 to evaluate
     // height based locks because when SequenceLocks() is called within
-    // CBlock::AcceptBlock(), the height of the block *being*
-    // evaluated is what is used. Thus if we want to know if a
-    // transaction can be part of the *next* block, we need to call
-    // SequenceLocks() with one more than chainActive.Height().
+    // ConnectBlock(), the height of the block *being*
+    // evaluated is what is used.
+    // Thus if we want to know if a transaction can be part of the
+    // *next* block, we need to use one more than pindexBest->nHeight
     index.nHeight = pindexBest->nHeight + 1;
 
     std::vector<int> prevheights;
@@ -987,8 +986,6 @@ bool CTxMemPool::accept(CTxDB& txdb, CTransaction &tx, bool fCheckInputs,
         // Only accept BIP68 sequence locked transactions that can be mined in the next
         // block; we don't want our mempool filled up with transactions that can't
         // be mined yet.
-        // Must keep pool.cs for this unless we change CheckSequenceLocks to take a
-        // CoinsViewCache instead of create its own
         if (!CheckSequenceLocks(tx, STANDARD_LOCKTIME_VERIFY_FLAGS))
         {
             return error("CTxMemPool::accept() : non-BIP68-final transaction");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -427,7 +427,7 @@ static std::pair<int, int64_t> CalculateSequenceLocks(const CTransaction &tx,
         if (txin.nSequence & CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG)
         {
             CBlockIndex *pbi = FindBlockByHeight(std::max(nCoinHeight - 1, 0));
-            int64_t nCoinTime = pbi->GetMedianTimePast();
+            int64_t nCoinTime = pbi->GetBlockTime();
             // NOTE: Subtract 1 to maintain nLockTime semantics
             // BIP 68 relative lock times have the semantics of calculating
             // the first block or time at which the transaction would be
@@ -455,7 +455,7 @@ static std::pair<int, int64_t> CalculateSequenceLocks(const CTransaction &tx,
 static bool EvaluateSequenceLocks(const CBlockIndex& block, std::pair<int, int64_t> lockPair)
 {
     assert(block.pprev);
-    int64_t nBlockTime = block.pprev->GetMedianTimePast();
+    int64_t nBlockTime = block.pprev->GetBlockTime();
     if (lockPair.first >= block.nHeight || lockPair.second >= nBlockTime)
         return false;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -456,8 +456,20 @@ static bool EvaluateSequenceLocks(const CBlockIndex& block, std::pair<int, int64
 {
     assert(block.pprev);
     int64_t nBlockTime = block.pprev->GetBlockTime();
-    if (lockPair.first >= block.nHeight || lockPair.second >= nBlockTime)
+    if (lockPair.first >= block.nHeight)
+    {
+        printf("EvaluateSequenceLocks, failed to use relative time-lock coins, current block height  = %d"
+                ", the coin inputs can only be used in a block with height > %d\n", block.nHeight, lockPair.first);
         return false;
+    }
+    else if (lockPair.second >= nBlockTime)
+    {
+        printf("EvaluateSequenceLocks, failed to use relative time-lock coins, current block time  = %ld"
+                ", the coin inputs can only be used after a block with block time > %d was mined\n",
+                DateTimeStrFormat(nBlockTime),
+                DateTimeStrFormat(lockPair.second));
+        return false;
+    }
 
     return true;
 }

--- a/src/main.h
+++ b/src/main.h
@@ -214,7 +214,20 @@ extern unsigned char GetNfactor(::int64_t nTimestamp, bool fYac1dot0BlockOrTx = 
 unsigned int GetProofOfWorkMA(const CBlockIndex* pIndexLast);
 unsigned int GetProofOfWorkSMA(const CBlockIndex* pIndexLast);
 
+/**
+ * Check if transaction is final per BIP 68 sequence numbers and can be included in a block.
+ * Consensus critical. Takes as input a list of heights at which tx's inputs (in order) confirmed.
+ */
+bool SequenceLocks(const CTransaction &tx, int flags, std::vector<int>* prevHeights, const CBlockIndex& block);
 
+/**
+ * Check if transaction will be BIP 68 final in the next block to be created.
+ *
+ * Calls SequenceLocks() with data from the tip of the current active chain.
+ *
+ * See consensus/consensus.h for flag definitions.
+ */
+bool CheckSequenceLocks(const CTransaction &tx, int flags);
 
 
 

--- a/src/main.h
+++ b/src/main.h
@@ -383,22 +383,22 @@ public:
     static const uint32_t SEQUENCE_LOCKTIME_DISABLE_FLAG = (1 << 31);
 
     /* If CTxIn::nSequence encodes a relative lock-time and this flag
-     * is set, the relative lock-time has units of 512 seconds,
+     * is set, the relative lock-time has units of 1 seconds,
      * otherwise it specifies blocks with a granularity of 1. */
-    static const uint32_t SEQUENCE_LOCKTIME_TYPE_FLAG = (1 << 22);
+    static const uint32_t SEQUENCE_LOCKTIME_TYPE_FLAG = (1 << 30);
 
     /* If CTxIn::nSequence encodes a relative lock-time, this mask is
      * applied to extract that lock-time from the sequence field. */
-    static const uint32_t SEQUENCE_LOCKTIME_MASK = 0x0000ffff;
+    static const uint32_t SEQUENCE_LOCKTIME_MASK = 0x2fffffff;
 
     /* In order to use the same number of bits to encode roughly the
      * same wall-clock duration, and because blocks are naturally
-     * limited to occur every 600s on average, the minimum granularity
-     * for time-based relative lock-time is fixed at 512 seconds.
+     * limited to occur every 60s on average, the minimum granularity
+     * for time-based relative lock-time is fixed at 1 seconds.
      * Converting from CTxIn::nSequence to seconds is performed by
-     * multiplying by 512 = 2^9, or equivalently shifting up by
-     * 9 bits. */
-    static const int SEQUENCE_LOCKTIME_GRANULARITY = 9;
+     * multiplying by 1 = 2^0, or equivalently shifting up by
+     * 0 bits. */
+    static const int SEQUENCE_LOCKTIME_GRANULARITY = 0;
 
     CTxIn()
     {

--- a/src/main.h
+++ b/src/main.h
@@ -360,19 +360,46 @@ public:
     CScript scriptSig;
     ::uint32_t nSequence;
 
+    /* Setting nSequence to this value for every input in a transaction
+     * disables nLockTime. */
+    static const uint32_t SEQUENCE_FINAL = 0xffffffff;
+
+    /* Below flags apply in the context of BIP 68*/
+    /* If this flag set, CTxIn::nSequence is NOT interpreted as a
+     * relative lock-time. */
+    static const uint32_t SEQUENCE_LOCKTIME_DISABLE_FLAG = (1 << 31);
+
+    /* If CTxIn::nSequence encodes a relative lock-time and this flag
+     * is set, the relative lock-time has units of 512 seconds,
+     * otherwise it specifies blocks with a granularity of 1. */
+    static const uint32_t SEQUENCE_LOCKTIME_TYPE_FLAG = (1 << 22);
+
+    /* If CTxIn::nSequence encodes a relative lock-time, this mask is
+     * applied to extract that lock-time from the sequence field. */
+    static const uint32_t SEQUENCE_LOCKTIME_MASK = 0x0000ffff;
+
+    /* In order to use the same number of bits to encode roughly the
+     * same wall-clock duration, and because blocks are naturally
+     * limited to occur every 600s on average, the minimum granularity
+     * for time-based relative lock-time is fixed at 512 seconds.
+     * Converting from CTxIn::nSequence to seconds is performed by
+     * multiplying by 512 = 2^9, or equivalently shifting up by
+     * 9 bits. */
+    static const int SEQUENCE_LOCKTIME_GRANULARITY = 9;
+
     CTxIn()
     {
-        nSequence = std::numeric_limits<unsigned int>::max();
+        nSequence = SEQUENCE_FINAL;
     }
 
-    explicit CTxIn(COutPoint prevoutIn, CScript scriptSigIn=CScript(), unsigned int nSequenceIn=std::numeric_limits<unsigned int>::max())
+    explicit CTxIn(COutPoint prevoutIn, CScript scriptSigIn=CScript(), unsigned int nSequenceIn=SEQUENCE_FINAL)
     {
         prevout = prevoutIn;
         scriptSig = scriptSigIn;
         nSequence = nSequenceIn;
     }
 
-    CTxIn(uint256 hashPrevTx, unsigned int nOut, CScript scriptSigIn=CScript(), unsigned int nSequenceIn=std::numeric_limits<unsigned int>::max())
+    CTxIn(uint256 hashPrevTx, unsigned int nOut, CScript scriptSigIn=CScript(), unsigned int nSequenceIn=SEQUENCE_FINAL)
     {
         prevout = COutPoint(hashPrevTx, nOut);
         scriptSig = scriptSigIn;
@@ -388,7 +415,7 @@ public:
 
     bool IsFinal() const
     {
-        return (nSequence == std::numeric_limits<unsigned int>::max());
+        return (nSequence == SEQUENCE_FINAL);
     }
 
     friend bool operator==(const CTxIn& a, const CTxIn& b)
@@ -417,7 +444,7 @@ public:
             str += strprintf(", coinbase %s", HexStr(scriptSig).c_str());
         else
             str += strprintf(", scriptSig=%s", scriptSig.ToString().substr(0,24).c_str());
-        if (nSequence != std::numeric_limits<unsigned int>::max())
+        if (nSequence != SEQUENCE_FINAL)
             str += strprintf(", nSequence=%u", nSequence);
         str += ")";
         return str;
@@ -620,7 +647,7 @@ public:
                 return false;
 
         bool fNewer = false;
-        unsigned int nLowest = std::numeric_limits<unsigned int>::max();
+        unsigned int nLowest = CTxIn::SEQUENCE_FINAL;
         for (unsigned int i = 0; i < vin.size(); i++)
         {
             if (vin[i].nSequence != old.vin[i].nSequence)

--- a/src/main.h
+++ b/src/main.h
@@ -389,7 +389,7 @@ public:
 
     /* If CTxIn::nSequence encodes a relative lock-time, this mask is
      * applied to extract that lock-time from the sequence field. */
-    static const uint32_t SEQUENCE_LOCKTIME_MASK = 0x2fffffff;
+    static const uint32_t SEQUENCE_LOCKTIME_MASK = 0x3fffffff;
 
     /* In order to use the same number of bits to encode roughly the
      * same wall-clock duration, and because blocks are naturally

--- a/src/main.h
+++ b/src/main.h
@@ -222,10 +222,6 @@ bool SequenceLocks(const CTransaction &tx, int flags, std::vector<int>* prevHeig
 
 /**
  * Check if transaction will be BIP 68 final in the next block to be created.
- *
- * Calls SequenceLocks() with data from the tip of the current active chain.
- *
- * See consensus/consensus.h for flag definitions.
  */
 bool CheckSequenceLocks(const CTransaction &tx, int flags);
 

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -28,6 +28,7 @@ using std::set;
 
 bool CheckSig(vector<unsigned char> vchSig, const vector<unsigned char> &vchPubKey, const CScript &scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType, int flags);
 bool CheckLockTime(const CTransaction& txTo, unsigned int nIn, const CScriptNum& nLockTime);
+bool CheckSequence(const CTransaction& txTo, unsigned int nIn, const CScriptNum& nSequence);
 
 static const valtype vchFalse(0);
 static const valtype vchZero(0);
@@ -459,7 +460,44 @@ bool EvalScript(
 
                     break;
                 }
-                case OP_NOP1: case OP_NOP3: case OP_NOP4: case OP_NOP5:
+
+                case OP_CHECKSEQUENCEVERIFY:
+                {
+                    if (!(flags & SCRIPT_VERIFY_CHECKSEQUENCEVERIFY)) {
+                        // not enabled; treat as a NOP3
+                        break;
+                    }
+
+                    if (stack.size() < 1)
+//                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return false;
+
+                    // nSequence, like nLockTime, is a 32-bit unsigned integer
+                    // field. See the comment in CHECKLOCKTIMEVERIFY regarding
+                    // 5-byte numeric operands.
+                    const CScriptNum nSequence(stacktop(-1), 5);
+
+                    // In the rare event that the argument may be < 0 due to
+                    // some arithmetic being done first, you can always use
+                    // 0 MAX CHECKSEQUENCEVERIFY.
+                    if (nSequence < 0)
+//                        return set_error(serror, SCRIPT_ERR_NEGATIVE_LOCKTIME);
+                        return false;
+
+                    // To provide for future soft-fork extensibility, if the
+                    // operand has the disabled lock-time flag set,
+                    // CHECKSEQUENCEVERIFY behaves as a NOP.
+                    if ((nSequence & CTxIn::SEQUENCE_LOCKTIME_DISABLE_FLAG) != 0)
+                        break;
+
+                    // Compare the specified sequence number with the input.
+                    if (!CheckSequence(txTo, nIn, nSequence))
+//                        return set_error(serror, SCRIPT_ERR_UNSATISFIED_LOCKTIME);
+                        return false;
+
+                    break;
+                }
+                case OP_NOP1: case OP_NOP4: case OP_NOP5:
                 case OP_NOP6: case OP_NOP7: case OP_NOP8: case OP_NOP9: case OP_NOP10:
                 break;
 
@@ -1356,6 +1394,53 @@ bool CheckLockTime(const CTransaction& txTo, unsigned int nIn, const CScriptNum&
     // inputs, but testing just this input minimizes the data
     // required to prove correct CHECKLOCKTIMEVERIFY execution.
     if (txTo.vin[nIn].IsFinal())
+        return false;
+
+    return true;
+}
+
+bool CheckSequence(const CTransaction& txTo, unsigned int nIn, const CScriptNum& nSequence)
+{
+    // Relative lock times are supported by comparing the passed
+    // in operand to the sequence number of the input.
+    const int64_t txToSequence = (int64_t)txTo.vin[nIn].nSequence;
+
+//    // Fail if the transaction's version number is not set high
+//    // enough to trigger BIP 68 rules.
+//    if (static_cast<uint32_t>(txTo.nVersion) < 2)
+//        return false;
+
+    // Sequence numbers with their most significant bit set are not
+    // consensus constrained. Testing that the transaction's sequence
+    // number do not have this bit set prevents using this property
+    // to get around a CHECKSEQUENCEVERIFY check.
+    if (txToSequence & CTxIn::SEQUENCE_LOCKTIME_DISABLE_FLAG)
+        return false;
+
+    // Mask off any bits that do not have consensus-enforced meaning
+    // before doing the integer comparisons
+    const uint32_t nLockTimeMask = CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG | CTxIn::SEQUENCE_LOCKTIME_MASK;
+    const int64_t txToSequenceMasked = txToSequence & nLockTimeMask;
+    const CScriptNum nSequenceMasked = nSequence & nLockTimeMask;
+
+    // There are two kinds of nSequence: lock-by-blockheight
+    // and lock-by-blocktime, distinguished by whether
+    // nSequenceMasked < CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG.
+    //
+    // We want to compare apples to apples, so fail the script
+    // unless the type of nSequenceMasked being tested is the same as
+    // the nSequenceMasked in the transaction.
+    if (!((txToSequenceMasked < CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG
+            && nSequenceMasked < CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG)
+            || (txToSequenceMasked >= CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG
+                    && nSequenceMasked >= CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG)))
+    {
+        return false;
+    }
+
+    // Now that we know we're comparing apples-to-apples, the
+    // comparison is a simple numeric one.
+    if (nSequenceMasked > txToSequenceMasked)
         return false;
 
     return true;

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1559,6 +1559,9 @@ bool Solver(
         // CLTV transaction, sender provides hash of pubkey, receiver provides redeemscript and signature
         mTemplates.insert(make_pair(TX_CLTV, CScript() << OP_SMALLDATA << OP_NOP2 << OP_DROP << OP_PUBKEYS << OP_CHECKSIG));
 
+        // CSV transaction, sender provides hash of pubkey, receiver provides redeemscript and signature
+        mTemplates.insert(make_pair(TX_CSV, CScript() << OP_SMALLDATA << OP_NOP3 << OP_DROP << OP_PUBKEYS << OP_CHECKSIG));
+
         if (!fUseOld044Rules)
         {   // Empty, provably prunable, data-carrying output
             mTemplates.insert(make_pair(TX_NULL_DATA, CScript() << OP_RETURN << OP_SMALLDATA));
@@ -1947,6 +1950,7 @@ isminetype IsMine(const CKeyStore &keystore, const CScript& scriptPubKey)
         break;
     }
     case TX_CLTV:
+    case TX_CSV:
     {
        keyID = CPubKey(vSolutions[0]).GetID();
         if (keystore.HaveKey(keyID))
@@ -2397,6 +2401,15 @@ void CScript::SetCltv(int nLockTime, const CPubKey& pubKey)
     *this << nLockTime;
     *this << OP_CHECKLOCKTIMEVERIFY << OP_DROP;
 	*this << pubKey << OP_CHECKSIG;
+}
+
+void CScript::SetCsv(::uint32_t nSequence, const CPubKey& pubKey)
+{
+    this->clear();
+
+    *this << (CScriptNum)nSequence;
+    *this << OP_CHECKSEQUENCEVERIFY << OP_DROP;
+    *this << pubKey << OP_CHECKSIG;
 }
 #ifdef _MSC_VER
     #include "msvc_warnings.pop.h"

--- a/src/script.h
+++ b/src/script.h
@@ -216,6 +216,11 @@ enum
     //
     // See BIP65 for details.
     SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY = (1U << 9),
+
+    // support CHECKSEQUENCEVERIFY opcode
+    //
+    // See BIP112 for details
+    SCRIPT_VERIFY_CHECKSEQUENCEVERIFY = (1U << 10),
 };
 
 /** Flags for nSequence and nLockTime locks */
@@ -243,7 +248,7 @@ static const unsigned int MANDATORY_SCRIPT_VERIFY_FLAGS = SCRIPT_VERIFY_P2SH;
 // Standard script verification flags that standard transactions will comply
 // with. However scripts violating these flags may still be present in valid
 // blocks and we must accept those blocks.
-static const unsigned int STRICT_FLAGS = MANDATORY_SCRIPT_VERIFY_FLAGS | STRICT_FORMAT_FLAGS | SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
+static const unsigned int STRICT_FLAGS = MANDATORY_SCRIPT_VERIFY_FLAGS | STRICT_FORMAT_FLAGS | SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY | SCRIPT_VERIFY_CHECKSEQUENCEVERIFY;
 
 // Soft verifications, no extended signature format checkings
 static const unsigned int SOFT_FLAGS = STRICT_FLAGS & ~STRICT_FORMAT_FLAGS;
@@ -393,6 +398,7 @@ enum opcodetype
     OP_NOP2 = 0xb1,
 	OP_CHECKLOCKTIMEVERIFY = OP_NOP2,
     OP_NOP3 = 0xb2,
+    OP_CHECKSEQUENCEVERIFY = OP_NOP3,
     OP_NOP4 = 0xb3,
     OP_NOP5 = 0xb4,
     OP_NOP6 = 0xb5,

--- a/src/script.h
+++ b/src/script.h
@@ -769,6 +769,7 @@ bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType);
 isminetype IsMine(const CKeyStore& keystore, const CScript& scriptPubKey);
 isminetype IsMine(const CKeyStore& keystore, const CTxDestination& dest);
 bool IsSpendableCltvUTXO(const CKeyStore &keystore, const CScript& scriptPubKey);
+bool IsSpendableCsvUTXO(const CKeyStore &keystore, const CScript& scriptPubKey);
 void ExtractAffectedKeys(const CKeyStore &keystore, const CScript& scriptPubKey, std::vector<CKeyID> &vKeys);
 bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet);
 bool ExtractDestinations(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<CTxDestination>& addressRet, int& nRequiredRet);

--- a/src/script.h
+++ b/src/script.h
@@ -209,6 +209,12 @@ enum
     SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY = (1U << 9),
 };
 
+/** Flags for nSequence and nLockTime locks */
+enum {
+    /* Interpret sequence numbers as relative lock-time constraints. */
+    LOCKTIME_VERIFY_SEQUENCE = (1 << 0),
+};
+
 // Strict verification:
 //
 // * force DER encoding;
@@ -232,6 +238,9 @@ static const unsigned int STRICT_FLAGS = MANDATORY_SCRIPT_VERIFY_FLAGS | STRICT_
 
 // Soft verifications, no extended signature format checkings
 static const unsigned int SOFT_FLAGS = STRICT_FLAGS & ~STRICT_FORMAT_FLAGS;
+
+/** Used as the flags parameter to sequence and nLocktime checks in non-consensus code. */
+static const unsigned int STANDARD_LOCKTIME_VERIFY_FLAGS = LOCKTIME_VERIFY_SEQUENCE;
 
 enum txnouttype
 {

--- a/src/script.h
+++ b/src/script.h
@@ -86,6 +86,9 @@ public:
 
     inline CScriptNum& operator+=( const CScriptNum& rhs)       { return operator+=(rhs.m_value);  }
     inline CScriptNum& operator-=( const CScriptNum& rhs)       { return operator-=(rhs.m_value);  }
+    inline CScriptNum operator&(   const int64_t& rhs)    const { return CScriptNum(m_value & rhs);}
+    inline CScriptNum operator&(   const CScriptNum& rhs) const { return operator&(rhs.m_value);   }
+    inline CScriptNum& operator&=( const CScriptNum& rhs)       { return operator&=(rhs.m_value);  }
 
     inline CScriptNum operator-()                         const
     {
@@ -112,6 +115,12 @@ public:
         assert(rhs == 0 || (rhs > 0 && m_value >= std::numeric_limits<int64_t>::min() + rhs) ||
                            (rhs < 0 && m_value <= std::numeric_limits<int64_t>::max() + rhs));
         m_value -= rhs;
+        return *this;
+    }
+
+    inline CScriptNum& operator&=( const int64_t& rhs)
+    {
+        m_value &= rhs;
         return *this;
     }
 

--- a/src/script.h
+++ b/src/script.h
@@ -265,6 +265,7 @@ enum txnouttype
     TX_SCRIPTHASH,
     TX_MULTISIG,
 	TX_CLTV,
+	TX_CSV,
     TX_NULL_DATA,
 };
 
@@ -716,6 +717,7 @@ public:
     void SetDestination(const CTxDestination& address);
     void SetMultisig(int nRequired, const std::vector<CKey>& keys);
     void SetCltv(int nLockTime, const CPubKey& pubKey);
+    void SetCsv(::uint32_t nSequence, const CPubKey& pubKey);
 
     void PrintHex() const
     {

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1930,7 +1930,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> > &vecSend,
                 BOOST_FOREACH(const PAIRTYPE(const CWalletTx*,unsigned int)& coin, setCoins)
                 {
                 	// In order nLockTime and OP_CHECKLOCKTIMEVERIFY can work, set nSequence to another value which different with maxint
-                	unsigned int nSequenceIn = std::numeric_limits<unsigned int>::max();
+                    unsigned int nSequenceIn = CTxIn::SEQUENCE_FINAL;
                 	if (IsSpendableCltvUTXO(coin.first->vout[coin.second]))
                 	{
                 		nSequenceIn = 0;

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -54,6 +54,12 @@ struct CompareValueOnly
     }
 };
 
+bool compareUTXO(COutput u1, COutput u2)
+{
+    return (u1.nDepth > u2.nDepth);
+}
+
+
 CPubKey CWallet::GenerateNewKey()
 {
     bool fCompressed = CanSupportFeature(FEATURE_COMPRPUBKEY); // default to compressed public keys if we want 0.6.0 wallets
@@ -1674,7 +1680,7 @@ bool CWallet::SelectCoinsMinConf(int64_t nTargetValue, int64_t nSpendTime, int n
     vector<pair< int64_t, pair<const CWalletTx*,unsigned int> > > vValue;
     int64_t nTotalLower = 0;
 
-    random_shuffle(vCoins.begin(), vCoins.end(), GetRandInt);
+    sort(vCoins.begin(), vCoins.end(), compareUTXO);
 
     BOOST_FOREACH(const COutput &output, vCoins)
     {

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -170,7 +170,7 @@ public:
     bool CanSupportFeature(enum WalletFeature wf) { return nWalletMaxVersion >= wf; }
 
     void AvailableCoinsMinConf(std::vector<COutput>& vCoins, int nConf, ::int64_t nMinValue, ::int64_t nMaxValue) const;
-    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl=NULL, const CScript *fromScriptPubKey=NULL, bool fCountCltv=false) const;
+    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl=NULL, const CScript *fromScriptPubKey=NULL, bool fCountCltvOrCsv=false) const;
     bool SelectCoinsMinConf(::int64_t nTargetValue, int64_t nSpendTime, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, ::int64_t& nValueRet) const;
     // keystore implementation
     // Generate a new key
@@ -296,6 +296,10 @@ public:
     bool IsSpendableCltvUTXO(const CTxOut& txout) const
     {
         return ::IsSpendableCltvUTXO(*this, txout.scriptPubKey);
+    }
+    bool IsSpendableCsvUTXO(const CTxOut& txout) const
+    {
+        return ::IsSpendableCsvUTXO(*this, txout.scriptPubKey);
     }
     ::int64_t GetCredit(const CTxOut& txout, const isminefilter& filter) const
     {


### PR DESCRIPTION
Hi all,
This PR contains all changes relating to OP_CHECKSEQUENCEVERIFY and two RPC commands "createcsvaddress", "spendcsv"

Test scenario, video demo and instruction how to use rpc commands:
1) Block height-based relative lock-times:
Instruction/test scenario: https://trello-attachments.s3.amazonaws.com/5e258c849f74416a02536a94/5e7cffe717e5c073ab54028a/9c0b841d5a03e1d03b10cda5a3caac6f/Instruction_csv.txt
Demo video: https://drive.google.com/file/d/1WvS83U7FxIWcSIkhcIJTS-nGa9T8Crcv/view?usp=sharing

2) Time-based relative lock-times
Instruction/test scenario: https://trello-attachments.s3.amazonaws.com/5e258c849f74416a02536a94/5e7cffe717e5c073ab54028a/225fb9da5f3c493de02c4510a2264ca9/Instruction_csv_timebased.txt
Demo video: https://drive.google.com/file/d/1XAEEo1CPEboiaosnltECPpKz1QszQZCe/view?usp=sharing

Note: You should download video and watch on your PC, you can use VLC to watch it. Because the default resolution is not good if you watch it directly on google drive.