### PR TITLE
Fix slow sync time

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -553,7 +553,7 @@ bool AppInit2()
 
     nNodeLifespan = (unsigned int)(GetArg("-addrlifespan", 7));
     fUseFastIndex = GetBoolArg("-fastindex", true);
-    fStoreBlockHashToDb = GetBoolArg("-storeblockhash", false);
+    fStoreBlockHashToDb = GetBoolArg("-storeblockhash", true);
     fUseMemoryLog = GetBoolArg("-memorylog", true);
     nMinerSleep = (unsigned int)(GetArg("-minersleep", nOneHundredMilliseconds));
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -55,6 +55,7 @@ bool fConfChange;
 unsigned int nNodeLifespan;
 unsigned int nMinerSleep;
 bool fUseFastIndex;
+bool fStoreBlockHashToDb;
 bool fUseFastStakeMiner;
 bool fUseMemoryLog;
 enum Checkpoints::CPMode CheckpointsMode;
@@ -552,6 +553,7 @@ bool AppInit2()
 
     nNodeLifespan = (unsigned int)(GetArg("-addrlifespan", 7));
     fUseFastIndex = GetBoolArg("-fastindex", true);
+    fStoreBlockHashToDb = GetBoolArg("-storeblockhash", false);
     fUseMemoryLog = GetBoolArg("-memorylog", true);
     nMinerSleep = (unsigned int)(GetArg("-minersleep", nOneHundredMilliseconds));
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1380,7 +1380,7 @@ bool CBlock::ReadFromDisk(unsigned int nFile, unsigned int nBlockPos,
     }
     // Check the header
     if (fReadTransactions && IsProofOfWork()
-            && (fCheckHeader && !CheckProofOfWork(GetYacoinHash(), nBits)))
+            && (fCheckHeader && !CheckProofOfWork(GetHash(), nBits)))
         return error("CBlock::ReadFromDisk() : errors in block header");
 
     return true;
@@ -3773,7 +3773,7 @@ bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, bool fCheckSig) c
             return DoS(50, error("CheckBlock () : zero nonce in proof-of-work block"));
 
         // Check proof of work matches claimed amount
-        if (fCheckPOW && !CheckProofOfWork(GetYacoinHash(), nBits))
+        if (fCheckPOW && !CheckProofOfWork(GetHash(), nBits))
             return DoS(50, error("CheckBlock () : proof of work failed"));
 
         // Check timestamp
@@ -4380,7 +4380,7 @@ bool CBlock::SignBlock044(const CKeyStore& keystore)
                     continue;
                 if(
                     !key.Sign(
-                                GetYacoinHash(),    //<<<<<<<<<<<<<<< test
+                                GetHash(),    //<<<<<<<<<<<<<<< test
                                 //GetHash(), 
                                 vchBlockSig
                              )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3902,39 +3902,6 @@ bool CBlock::AcceptBlock()
     if (!Checkpoints::CheckHardened(nHeight, hash))
         return DoS(100, error("AcceptBlock () : rejected by hardened checkpoint lock-in at %d", nHeight));
 
-    if (nBestHeight < nMainnetNewLogicBlockNumber)
-    {
-        bool cpSatisfies = Checkpoints::CheckSync(hash, pindexPrev);
-
-        // Check that the block satisfies synchronized checkpoint
-        if (
-            (CheckpointsMode == Checkpoints::STRICT_) &&
-    /**************
-        // using STRICT instead of STRICT_ collides with windef.h
-        // and strangely cause gcc to fail when WIN32 is true & QT_GUI
-        // but not WIN32 gcc compiling the daemon???
-        // so I changed to STRICT_ which doesn't collide!
-        // if we don't then this if would have to look like
-        if (
-            (CheckpointsMode ==
-    #ifdef WIN32 && QT_GUI
-             0
-    #else
-             Checkpoints::STRICT
-    #endif
-            ) &&
-    ***************/
-            !cpSatisfies
-           )
-            return error("AcceptBlock () : rejected by synchronized checkpoint");
-
-        if (
-            (CheckpointsMode == Checkpoints::ADVISORY) &&
-            !cpSatisfies
-           )
-            strMiscWarning = _("WARNING: syncronized checkpoint violation detected, but skipped!");
-    }
-
     // Enforce rule that the coinbase starts with serialized block height
     CScript expect = CScript() << nHeight;
     if (

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5890,10 +5890,17 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         pfrom->AddInventoryKnown(inv);
 
         Sleep( nOneMillisecond );  // let's try this arbitrary value? 
+
+        MeasureTime processBlock;
         if (ProcessBlock(pfrom, &block))
         {
             mapAlreadyAskedFor.erase(inv);
         }
+        processBlock.mEnd.stamp();
+
+        printf("Process block message, total time for ProcessBlock = %lu us\n",
+                processBlock.getExecutionTime());
+
         //if( !IsInitialBlockDownload() )        {}
         if (block.nDoS) 
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1374,7 +1374,7 @@ bool CBlock::ReadFromDisk(unsigned int nFile, unsigned int nBlockPos,
     }
 
     CTxDB txdb("r");
-    if (!txdb.ReadBlockHash(nFile, nBlockPos, blockHash))
+    if (fStoreBlockHashToDb && !txdb.ReadBlockHash(nFile, nBlockPos, blockHash))
     {
         printf("CBlock::ReadFromDisk(): can't read block hash at file = %d, block pos = %d\n", nFile, nBlockPos);
     }
@@ -2986,7 +2986,7 @@ bool CBlock::DisconnectBlock(CTxDB& txdb, CBlockIndex* pindex)
         blockindexPrev.hashNext = 0;
         if (!txdb.WriteBlockIndex(blockindexPrev))
             return error("DisconnectBlock() : WriteBlockIndex failed");
-        if (!txdb.WriteBlockHash(blockindexPrev))
+        if (fStoreBlockHashToDb && !txdb.WriteBlockHash(blockindexPrev))
         {
             printf("CBlock::DisconnectBlock(): Can't WriteBlockHash\n");
             return error("DisconnectBlock() : WriteBlockHash failed");
@@ -3179,7 +3179,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
     pindex->nMoneySupply = (pindex->pprev? pindex->pprev->nMoneySupply : 0) + nValueOut - nValueIn;
     if (!txdb.WriteBlockIndex(CDiskBlockIndex(pindex)))
         return error("Connect() : WriteBlockIndex for pindex failed");
-    if (!txdb.WriteBlockHash(CDiskBlockIndex(pindex)))
+    if (fStoreBlockHashToDb && !txdb.WriteBlockHash(CDiskBlockIndex(pindex)))
     {
         printf("Connect(): Can't WriteBlockHash\n");
         return error("Connect() : WriteBlockHash failed");
@@ -3208,7 +3208,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
         blockindexPrev.hashNext = pindex->GetBlockHash();
         if (!txdb.WriteBlockIndex(blockindexPrev))
             return error("ConnectBlock() : WriteBlockIndex failed");
-        if (!txdb.WriteBlockHash(blockindexPrev))
+        if (fStoreBlockHashToDb && !txdb.WriteBlockHash(blockindexPrev))
         {
             printf("ConnectBlock(): Can't WriteBlockHash\n");
             return error("ConnectBlock() : WriteBlockHash failed");
@@ -3654,7 +3654,7 @@ bool CBlock::AddToBlockIndex(unsigned int nFile, unsigned int nBlockPos)
     if (!txdb.TxnBegin())
         return false;
     txdb.WriteBlockIndex(CDiskBlockIndex(pindexNew));
-    if (!txdb.WriteBlockHash(CDiskBlockIndex(pindexNew)))
+    if (fStoreBlockHashToDb && !txdb.WriteBlockHash(CDiskBlockIndex(pindexNew)))
     {
         printf("AddToBlockIndex(): Can't WriteBlockHash\n");
     }

--- a/src/main.h
+++ b/src/main.h
@@ -1148,6 +1148,12 @@ public:
             const_cast<CBlock*>(this)->vtx.clear();
             const_cast<CBlock*>(this)->vchBlockSig.clear();
         }
+        previousBlockHeader.version = this->nVersion;
+        previousBlockHeader.prev_block = hashPrevBlock;
+        previousBlockHeader.merkle_root = hashMerkleRoot;
+        previousBlockHeader.timestamp = nTime;
+        previousBlockHeader.bits = nBits;
+        previousBlockHeader.nonce = nNonce;
     )
 
     void SetNull()

--- a/src/main.h
+++ b/src/main.h
@@ -1539,49 +1539,6 @@ public:
         return true;
     }
 
-    bool ReadFromDisk(
-                      unsigned int nFile, 
-                      unsigned int nBlockPos, 
-                      bool fReadTransactions = true,
-                      bool fCheckHeader = true
-                     )
-    {
-        SetNull();
-
-        // Open history file to read
-        CAutoFile filein = CAutoFile(OpenBlockFile(nFile, nBlockPos, "rb"), SER_DISK, CLIENT_VERSION);
-        if (!filein)
-            return error("CBlock::ReadFromDisk() : OpenBlockFile failed");
-        if (!fReadTransactions)
-            filein.nType |= SER_BLOCKHEADERONLY;
-
-        // Read block
-        try {
-            filein >> *this;
-        }
-        catch (std::exception &e) 
-        //catch (...) 
-        {
-            //(void)e;
-            return error("%s() : deserialize or I/O error", BOOST_CURRENT_FUNCTION);
-        }
-
-        // Check the header
-        if (
-            fReadTransactions && 
-            IsProofOfWork() && 
-            (
-             fCheckHeader &&           
-             !CheckProofOfWork(GetYacoinHash(), nBits)
-            )
-           )
-            return error("CBlock::ReadFromDisk() : errors in block header");
-
-        return true;
-    }
-
-
-
     void print() const
     {
         printf("CBlock(\n"
@@ -1620,6 +1577,8 @@ public:
     bool DisconnectBlock(CTxDB& txdb, CBlockIndex* pindex);
     bool ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck=false);
     bool ReadFromDisk(const CBlockIndex* pindex, bool fReadTransactions=true, bool fCheckHeader = true);
+    bool ReadFromDisk(unsigned int nFile, unsigned int nBlockPos,
+            bool fReadTransactions = true, bool fCheckHeader = true);
     bool SetBestChain(CTxDB& txdb, CBlockIndex* pindexNew);
     bool AddToBlockIndex(unsigned int nFile, unsigned int nBlockPos);
     bool CheckBlock(bool fCheckPOW=true, bool fCheckMerkleRoot=true, bool fCheckSig=true) const;

--- a/src/main.h
+++ b/src/main.h
@@ -1859,11 +1859,7 @@ public:
 
     uint256 GetBlockHash() const
     {
-        if (
-            fUseFastIndex &&
-            (nTime < GetAdjustedTime() - 24 * 60 * 60) &&   // block's time is ~< 1 day old
-            (blockHash != 0)
-           )
+        if (fUseFastIndex && (blockHash != 0))
             return blockHash;
 
         CBlock block;

--- a/src/main.h
+++ b/src/main.h
@@ -154,6 +154,7 @@ extern ::int64_t nMinimumInputValue;
 extern bool fUseFastIndex;
 extern int nScriptCheckThreads;
 extern const uint256 entropyStore[38];
+extern bool fStoreBlockHashToDb;
 
 // Minimum disk space required - used in CheckDiskSpace()
 static const ::uint64_t nMinDiskSpace = 52428800;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -899,8 +899,17 @@ bool CheckWork(CBlock* pblock, CWallet& wallet, CReserveKey& reservekey)
         }
 
         // Process this block the same as if we had received it from another node
+        MeasureTime processBlock;
         if (!ProcessBlock(NULL, pblock))
+        {
+            processBlock.mEnd.stamp();
+            printf("CheckWork(), total time for ProcessBlock = %lu us\n",
+                    processBlock.getExecutionTime());
             return error("CheckWork () : ProcessBlock, block not accepted");
+        }
+        processBlock.mEnd.stamp();
+        printf("CheckWork(), total time for ProcessBlock = %lu us\n",
+                processBlock.getExecutionTime());
     }
 
     return true;
@@ -954,8 +963,17 @@ bool CheckStake(CBlock* pblock, CWallet& wallet)
         }
 
         // Process this block the same as if we had received it from another node
+        MeasureTime processBlock;
         if (!ProcessBlock(NULL, pblock))
+        {
+            processBlock.mEnd.stamp();
+            printf("CheckStake(), total time for ProcessBlock = %lu us\n",
+                    processBlock.getExecutionTime());
             return error("CheckStake() : ProcessBlock, block not accepted");
+        }
+        processBlock.mEnd.stamp();
+        printf("CheckStake(), total time for ProcessBlock = %lu us\n",
+                processBlock.getExecutionTime());
     }
 
     return true;

--- a/src/scrypt.cpp
+++ b/src/scrypt.cpp
@@ -121,6 +121,7 @@ bool scrypt_hash(
                  unsigned char Nfactor
                 )
 {
+    MeasureTime scryptHash;
     if(
        0 != scrypt(
                    (const unsigned char *)input,
@@ -134,7 +135,15 @@ bool scrypt_hash(
                    32
                   )
       )
+    {
+        scryptHash.mEnd.stamp();
+        printf("scrypt_hash(): Total time = %lu (us), Nfactor = %d\n",
+                scryptHash.getExecutionTime(), Nfactor);
         return true;
+    }
+    scryptHash.mEnd.stamp();
+    printf("scrypt_hash(): Total time = %lu (us), Nfactor = %d\n",
+            scryptHash.getExecutionTime(), Nfactor);
     return false;
 }
 
@@ -281,7 +290,7 @@ const ::uint32_t
         {            
             return 0;
         }
-        ++hash_count;
+         ++hash_count;
         // Hash target can't be smaller than bnProofOfWorkLimit which is 00000fffff000000
         if (            
             ( 0 == ( hashc[31]))

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -281,6 +281,16 @@ bool CTxDB::WriteBlockIndex(const CDiskBlockIndex& blockindex)
     return Write(make_pair(string("blockindex"), blockindex.GetBlockHash()), blockindex);
 }
 
+bool CTxDB::WriteBlockHash(const CDiskBlockIndex& blockindex)
+{
+    return Write(make_pair(string("blockhash"), make_pair(blockindex.nFile, blockindex.nBlockPos)), blockindex.GetBlockHash());
+}
+
+bool CTxDB::ReadBlockHash(const unsigned int nFile, const unsigned int nBlockPos, uint256& blockhash)
+{
+    return Read(make_pair(string("blockhash"), make_pair(nFile, nBlockPos)), blockhash);
+}
+
 bool CTxDB::ReadHashBestChain(uint256& hashBestChain)
 {
     return Read(string("hashBestChain"), hashBestChain);

--- a/src/txdb-leveldb.h
+++ b/src/txdb-leveldb.h
@@ -235,6 +235,8 @@ public:
     bool ReadDiskTx(COutPoint outpoint, CTransaction& tx, CTxIndex& txindex);
     bool ReadDiskTx(COutPoint outpoint, CTransaction& tx);
     bool WriteBlockIndex(const CDiskBlockIndex& blockindex);
+    bool WriteBlockHash(const CDiskBlockIndex& blockindex);
+    bool ReadBlockHash(const unsigned int nFile, const unsigned int nBlockPos, uint256& blockhash);
     bool ReadHashBestChain(uint256& hashBestChain);
     bool WriteHashBestChain(uint256 hashBestChain);
     bool ReadBestInvalidTrust(CBigNum& bnBestInvalidTrust);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1563,6 +1563,28 @@ bool NewThread(void(*pfn)(void*), void* parg)
     return true;
 }
 
+void Timestamp::stamp()
+{
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    mValue = tv.tv_sec * 1000000 + tv.tv_usec;
+}
+
+uint64_t Timestamp::getValue() const
+{
+    return mValue;
+}
+
+MeasureTime::MeasureTime()
+{
+    mStart.stamp();
+}
+
+uint64_t MeasureTime::getExecutionTime() const
+{
+    return mEnd.getValue() - mStart.getValue();
+}
+
 #ifdef WIN32
 //_____________________________________________________________________________
 void

--- a/src/util.h
+++ b/src/util.h
@@ -596,5 +596,23 @@ inline ::uint64_t ByteReverse_64bit(::uint64_t value)
 	value = (value & 0x00FF00FF00FF00FF) << 8  | (value & 0xFF00FF00FF00FF00) >> 8;
 	return value;
 }
+
+struct Timestamp
+{
+    Timestamp() {mValue = 0;};
+    void stamp();
+    uint64_t getValue() const;
+private:
+    uint64_t mValue;
+};
+
+struct MeasureTime
+{
+    MeasureTime();
+    Timestamp mStart;
+    Timestamp mEnd;
+
+    uint64_t getExecutionTime() const;
+};
 #endif
 


### PR DESCRIPTION
Hi all

This PR contains all implementation to:
1. Fix slow sync time
2. Boost speed/performance for various operation: mining, create transaction, verify transaction, handling rpc command, verify block

I added the new option "storeblockhash" to trigger the new logic which calculate and store block hash to leveldb database, then yacoin will use this block hash for various operations, it helps to boost speed/performance for various operations in yacoin logic. By default, the value of "storeblockhash" is true

In the first time when existing nodes (node already synchronized blockchain) run the new yacoin version which include "storeblockhash" logic, it will take about 20 minutes at startup phase, this time is used to store hash of all blocks to leveldb database. It only happens one time.

In order to boost the block sync process, we need to use the build which contains this fix for both new nodes and existing nodes