### PR TITLE
Add headers-first logic and improve P2P logic (#100)

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -1212,6 +1212,7 @@ static const CRPCCommand vRPCCommands[] =
     { "help",                   &help,                   true,   false },
     { "stop",                   &stop,                   true,   true  },
     { "getbestblockhash",       &getbestblockhash,       true,   false },
+    { "gettimechaininfo",       &gettimechaininfo,       true,   false },
     { "getblockcount",          &getblockcount,          true,   false },
     { "getwalletinfo",          &getwalletinfo,          true,   false },
     { "getrpcinfo",             &getrpcinfo,             true,   false },

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -228,6 +228,7 @@ extern json_spirit::Value signrawtransaction(const json_spirit::Array& params, b
 extern json_spirit::Value sendrawtransaction(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value getbestblockhash(const json_spirit::Array& params, bool fHelp); // in rpcblockchain.cpp
+extern json_spirit::Value gettimechaininfo(const json_spirit::Array& params, bool fHelp); // in rpcblockchain.cpp
 extern json_spirit::Value getblockcount(const json_spirit::Array& params, bool fHelp); // in rpcblockchain.cpp
 extern json_spirit::Value getwalletinfo(const json_spirit::Array& params, bool fHelp); // in rpcblockchain.cpp
 extern bool isThisInGMT( time_t & tBlock, struct tm  &aTimeStruct );

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -56,6 +56,30 @@ namespace Checkpoints
         ( 550177, std::make_pair(uint256("0x000000087d507052cb66d5a3770cf62f8ff9196ab861ffec3452d939b818567b"), 1399962064) )
         ( 612177, std::make_pair(uint256("0x0000004bc02ebb045398fd8cdb249b790892a4fa3a8b03dbbbf5743c53f2a508"), 1404141665) )
         ( 712177, std::make_pair(uint256("0x000001881da9ee73de48a54ebae7d0dec3b453d795b6704d62414e4b581e3aea"), 1410900724) )
+        ( 750000, std::make_pair(uint256("0x000001d36056e88f70b27d1415cdf7cedbafb4a7c1f2f78d5a8d9f713aee4a5a"), 1413175439) )
+        ( 800000, std::make_pair(uint256("0x000000ca19b5cd837c373f40b5e511866c90ce37945fd43fe13e55fe51c22c06"), 1416125155) )
+        ( 850000, std::make_pair(uint256("0x0000003aa373b33950c52daf60c82f6e5dae67dba2b7affd0e0a95560ace68ce"), 1419136669) )
+        ( 900000, std::make_pair(uint256("0x0000029f3ce6e19adbf7c08e051b91c55d4586d99223964abc0387170c375bfd"), 1422263737) )
+        ( 950000, std::make_pair(uint256("0x0000031c836162928d81fd50bc8db3e995a80cbdef27785f7b11f46c86b327bb"), 1425401174) )
+        ( 1000000, std::make_pair(uint256("0x00000173fff346c1f83138ee23c15debb96eea78b63c8dea5e02da5e1a775a54"), 1428428793) )
+        ( 1050000, std::make_pair(uint256("0x00000118eb156fca5d4cea18ccc56d51175c9fa03e2301adc96d36dedbc4dd39"), 1431318185) )
+        ( 1100000, std::make_pair(uint256("0x000001875f4f515559d683c750db1952a1e5b896f6f4390023c6d445fef63f64"), 1434336775) )
+        ( 1150000, std::make_pair(uint256("0x00000979215bbb8205c42961b10b22900aa5c127e3a61061f340541295e65bf1"), 1437858183) )
+        ( 1200000, std::make_pair(uint256("0x0000084191c31d1c27cba87fbc4308b7e67cff8e89f13fcee51958db0e3918ee"), 1441219249) )
+        ( 1250000, std::make_pair(uint256("0x00000d72f9b23ae645eb875af19aa30279c597429ec5652da0e39a0edd5bd4f9"), 1445030340) )
+        ( 1300000, std::make_pair(uint256("0x00000a3336e2c336c0182945837573c5ffe68550f77393244d4bf26d36ae0f6c"), 1449046459) )
+        ( 1350000, std::make_pair(uint256("0x00000b6d09db4e5443094d05f8ea061e2305c44a787b5b4e3cdab9ddfa78034b"), 1452114905) )
+        ( 1400000, std::make_pair(uint256("0x0000061aa7e66eb0a1adcf5f4cf773eb6351a5e0905a3794cca135edc72799ab"), 1455489021) )
+        ( 1450000, std::make_pair(uint256("0x00000a99ea3603a90460600e8c1f4cb688abf8fcb8fc9d6a1848917690df049f"), 1458978981) )
+        ( 1500000, std::make_pair(uint256("0x0000072187440ce4016fa230c177a8967840d475278eff633dce66837e550f9e"), 1462246823) )
+        ( 1550000, std::make_pair(uint256("0x000005b5842fe8e453b7360c50cbe580ef4874d2b8976a3e5d336dc5e34b4683"), 1465161192) )
+        ( 1600000, std::make_pair(uint256("0x0000088ced0e7c97afb9635b315f286f94a25eb5d0490ce7b12e2ce0905c3f31"), 1468137164) )
+        ( 1650000, std::make_pair(uint256("0x000007439ff054f2307766a5a30eff4fc0268de68e72c76efde767ccee91830c"), 1474542850) )
+        ( 1700000, std::make_pair(uint256("0x00000797ae41dbf32c6cb73c1254fbd804b068263ef2de77755fb1829dd2ab1d"), 1485082994) )
+        ( 1750000, std::make_pair(uint256("0xd1806e1fa74087ef43fe0a8b37e558c1f9b523529f17b8cb91ca619dd90e4eec"), 1502581866) )
+        ( 1800000, std::make_pair(uint256("0x00000670c3f5b879d8b2b0c403c824af78cf95f536d2da66b198efcf9d9ff355"), 1538122573) )
+        ( 1850000, std::make_pair(uint256("0x00000e1b13b2b08d36598664d508a38500c59fcff4cf3d3746de0738b6eef457"), 1581200065) )
+        ( 1890005, std::make_pair(uint256("0x00000dfd4e2286daee184a67b9266e40b8c1c5daf3a29a2321fd23e6c2da62e2"), 1619355152) )
 #endif
         ;
 
@@ -212,7 +236,9 @@ namespace Checkpoints
                 CBlock block;
                 if (!block.ReadFromDisk(pindexCheckpoint))
                     return error("AcceptPendingSyncCheckpoint: ReadFromDisk failed for sync checkpoint %s", hashPendingCheckpoint.ToString().c_str());
-                if (!block.SetBestChain(txdb, pindexCheckpoint))
+                CValidationState state;
+                setBlockIndexCandidates.insert(pindexCheckpoint);
+                if (!ActivateBestChain(state, txdb))
                 {
                     hashInvalidCheckpoint = hashPendingCheckpoint;
                     return error("AcceptPendingSyncCheckpoint: SetBestChain failed for sync checkpoint %s", hashPendingCheckpoint.ToString().c_str());
@@ -242,9 +268,9 @@ namespace Checkpoints
     // Automatically select a suitable sync-checkpoint
     uint256 AutoSelectSyncCheckpoint()
     {
-        const CBlockIndex *pindex = pindexBest;
+        const CBlockIndex *pindex = chainActive.Tip();
         // Search backward for a block within max span and maturity window
-        while (pindex->pprev && (pindex->GetBlockTime() + CHECKPOINT_MAX_SPAN > pindexBest->GetBlockTime() || pindex->nHeight + 8 > pindexBest->nHeight))
+        while (pindex->pprev && (pindex->GetBlockTime() + CHECKPOINT_MAX_SPAN > chainActive.Tip()->GetBlockTime() || pindex->nHeight + 8 > chainActive.Tip()->nHeight))
             pindex = pindex->pprev;
         return pindex->GetBlockHash();
     }
@@ -277,19 +303,6 @@ namespace Checkpoints
         return true;
     }
 
-    bool WantedByPendingSyncCheckpoint(uint256 hashBlock)
-    {
-        LOCK(cs_hashSyncCheckpoint);
-        if (hashPendingCheckpoint == 0)
-            return false;
-        if (hashBlock == hashPendingCheckpoint)
-            return true;
-        if (mapOrphanBlocks.count(hashPendingCheckpoint) 
-            && hashBlock == WantedByOrphan(mapOrphanBlocks[hashPendingCheckpoint]))
-            return true;
-        return false;
-    }
-
     // ppcoin: reset synchronized checkpoint to last hardened checkpoint
     bool ResetSyncCheckpoint()
     {
@@ -303,7 +316,9 @@ namespace Checkpoints
             CBlock block;
             if (!block.ReadFromDisk(mapBlockIndex[hash]))
                 return error("ResetSyncCheckpoint: ReadFromDisk failed for hardened checkpoint %s", hash.ToString().c_str());
-            if (!block.SetBestChain(txdb, mapBlockIndex[hash]))
+            CValidationState state;
+            setBlockIndexCandidates.insert(mapBlockIndex[hash]);
+            if (!ActivateBestChain(state, txdb))
             {
                 return error("ResetSyncCheckpoint: SetBestChain failed for hardened checkpoint %s", hash.ToString().c_str());
             }
@@ -336,18 +351,6 @@ namespace Checkpoints
         return false;
     }
 
-    void AskForPendingSyncCheckpoint(CNode* pfrom)
-    {
-        LOCK(cs_hashSyncCheckpoint);
-        if (
-            pfrom && 
-            hashPendingCheckpoint != 0 && 
-            (!mapBlockIndex.count(hashPendingCheckpoint)) && 
-            (!mapOrphanBlocks.count(hashPendingCheckpoint))
-           )
-            pfrom->AskFor(CInv(MSG_BLOCK, hashPendingCheckpoint));
-    }
-
     bool SetCheckpointPrivKey(std::string strPrivKey)
     {
         // Test signing a sync-checkpoint with genesis block
@@ -368,37 +371,6 @@ namespace Checkpoints
         return true;
     }
 
-    bool SendSyncCheckpoint(uint256 hashCheckpoint)
-    {
-        CSyncCheckpoint checkpoint;
-        checkpoint.hashCheckpoint = hashCheckpoint;
-        CDataStream sMsg(SER_NETWORK, PROTOCOL_VERSION);
-        sMsg << (CUnsignedSyncCheckpoint)checkpoint;
-        checkpoint.vchMsg = std::vector<unsigned char>(sMsg.begin(), sMsg.end());
-
-        if (CSyncCheckpoint::strMasterPrivKey.empty())
-            return error("SendSyncCheckpoint: Checkpoint master key unavailable.");
-        std::vector<unsigned char> vchPrivKey = ParseHex(CSyncCheckpoint::strMasterPrivKey);
-        CKey key;
-        key.SetPrivKey(CPrivKey(vchPrivKey.begin(), vchPrivKey.end())); // if key is not correct openssl may crash
-        if (!key.Sign(Hash(checkpoint.vchMsg.begin(), checkpoint.vchMsg.end()), checkpoint.vchSig))
-            return error("SendSyncCheckpoint: Unable to sign checkpoint, check private key?");
-
-        if(!checkpoint.ProcessSyncCheckpoint(NULL))
-        {
-            printf("WARNING: SendSyncCheckpoint: Failed to process checkpoint.\n");
-            return false;
-        }
-
-        // Relay checkpoint
-        {
-            LOCK(cs_vNodes);
-            BOOST_FOREACH(CNode* pnode, vNodes)
-                checkpoint.RelayTo(pnode);
-        }
-        return true;
-    }
-
     // Is the sync-checkpoint outside maturity window?
     bool IsMatureSyncCheckpoint()
     {
@@ -406,7 +378,7 @@ namespace Checkpoints
         // sync-checkpoint should always be accepted block
         Yassert(mapBlockIndex.count(hashSyncCheckpoint));
         const CBlockIndex* pindexSync = mapBlockIndex[hashSyncCheckpoint];
-        return (nBestHeight >= pindexSync->nHeight + GetCoinbaseMaturity() ||
+        return (chainActive.Height() >= pindexSync->nHeight + GetCoinbaseMaturity() ||
                 pindexSync->GetBlockTime() + nStakeMinAge < GetAdjustedTime());
     }
 }
@@ -432,60 +404,6 @@ bool CSyncCheckpoint::CheckSignature()
     return true;
 }
 
-// process synchronized checkpoint
-bool CSyncCheckpoint::ProcessSyncCheckpoint(CNode* pfrom)
-{
-    if (!CheckSignature())
-        return false;
-
-    LOCK(Checkpoints::cs_hashSyncCheckpoint);
-    if (!mapBlockIndex.count(hashCheckpoint))
-    {
-        // We haven't received the checkpoint chain, keep the checkpoint as pending
-        Checkpoints::hashPendingCheckpoint = hashCheckpoint;
-        Checkpoints::checkpointMessagePending = *this;
-        printf("ProcessSyncCheckpoint: pending for sync-checkpoint %s\n", hashCheckpoint.ToString().c_str());
-        // Ask this guy to fill in what we're missing
-        if (pfrom)
-        {
-            pfrom->PushGetBlocks(pindexBest, hashCheckpoint);
-            // ask directly as well in case rejected earlier by duplicate
-            // proof-of-stake because getblocks may not get it this time
-            pfrom->AskFor(CInv(MSG_BLOCK, mapOrphanBlocks.count(hashCheckpoint)? WantedByOrphan(mapOrphanBlocks[hashCheckpoint]) : hashCheckpoint));
-        }
-        return false;
-    }
-
-    if (!Checkpoints::ValidateSyncCheckpoint(hashCheckpoint))
-        return false;
-
-    CTxDB txdb;
-    CBlockIndex* pindexCheckpoint = mapBlockIndex[hashCheckpoint];
-    if (!pindexCheckpoint->IsInMainChain())
-    {
-        // checkpoint chain received but not yet main chain
-        CBlock block;
-        if (!block.ReadFromDisk(pindexCheckpoint))
-            return error("ProcessSyncCheckpoint: ReadFromDisk failed for sync checkpoint %s", hashCheckpoint.ToString().c_str());
-        if (!block.SetBestChain(txdb, pindexCheckpoint))
-        {
-            Checkpoints::hashInvalidCheckpoint = hashCheckpoint;
-            return error("ProcessSyncCheckpoint: SetBestChain failed for sync checkpoint %s", hashCheckpoint.ToString().c_str());
-        }
-    }
-
-#ifndef USE_LEVELDB
-    txdb.Close();
-#endif
-
-    if (!Checkpoints::WriteSyncCheckpoint(hashCheckpoint))
-        return error("ProcessSyncCheckpoint(): failed to write sync checkpoint %s", hashCheckpoint.ToString().c_str());
-    Checkpoints::checkpointMessage = *this;
-    Checkpoints::hashPendingCheckpoint = 0;
-    Checkpoints::checkpointMessagePending.SetNull();
-    printf("ProcessSyncCheckpoint: sync-checkpoint at %s\n", hashCheckpoint.ToString().c_str());
-    return true;
-}
 #ifdef _MSC_VER
     #include "msvc_warnings.pop.h"
 #endif

--- a/src/checkpoints.h
+++ b/src/checkpoints.h
@@ -64,11 +64,8 @@ namespace Checkpoints
     bool AcceptPendingSyncCheckpoint();
     uint256 AutoSelectSyncCheckpoint();
     bool CheckSync(const uint256& hashBlock, const CBlockIndex* pindexPrev);
-    bool WantedByPendingSyncCheckpoint(uint256 hashBlock);
     bool ResetSyncCheckpoint();
-    void AskForPendingSyncCheckpoint(CNode* pfrom);
     bool SetCheckpointPrivKey(std::string strPrivKey);
-    bool SendSyncCheckpoint(uint256 hashCheckpoint);
     bool IsMatureSyncCheckpoint();
 }
 
@@ -159,7 +156,6 @@ public:
     }
 
     bool CheckSignature();
-    bool ProcessSyncCheckpoint(CNode* pfrom);
 };
 
 #endif

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -76,7 +76,7 @@ bool ScanForStakeKernelHash(MetaMap &mapMeta, ::uint32_t nBits, ::uint32_t nTime
 
 // Check kernel hash target and coinstake signature
 // Sets hashProofOfStake on success return
-bool CheckProofOfStake(const CTransaction& tx, unsigned int nBits, uint256& hashProofOfStake, uint256& targetProofOfStake);
+bool CheckProofOfStake(CValidationState &state, const CTransaction& tx, unsigned int nBits, uint256& hashProofOfStake, uint256& targetProofOfStake);
 
 // Get stake modifier checksum
 ::uint32_t GetStakeModifierChecksum(const CBlockIndex* pindex);

--- a/src/miner.h
+++ b/src/miner.h
@@ -28,7 +28,7 @@ void FormatHashBuffers_64bit_nTime(char* pblock, char* pmidstate, char* pdata, c
 bool CheckWork(CBlock* pblock, CWallet& wallet, CReserveKey& reservekey);
 
 /** Check mined proof-of-stake block */
-bool CheckStake(CBlock* pblock, CWallet& wallet);
+bool CheckStake(CValidationState& state, CBlock* pblock, CWallet& wallet);
 
 /** Base sha256 mining transform */
 void SHA256Transform(void* pstate, void* pinput, const void* pinit);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3,33 +3,33 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifdef _MSC_VER
-    #include <stdint.h>
+#include <stdint.h>
 
-    #include "msvc_warnings.push.h"
+#include "msvc_warnings.push.h"
 #endif
 
 #ifndef BITCOIN_IRC_H
- #include "irc.h"
+#include "irc.h"
 #endif
 
 #ifndef BITCOIN_DB_H
- #include "db.h"
+#include "db.h"
 #endif
 
 #ifndef BITCOIN_NET_H
- #include "net.h"
+#include "net.h"
 #endif
 
 #ifndef BITCOIN_INIT_H
- #include "init.h"
+#include "init.h"
 #endif
 
 #ifndef BITCOIN_STRLCPY_H
- #include "strlcpy.h"
+#include "strlcpy.h"
 #endif
 
 #ifndef NOVACOIN_MINER_H
- #include "miner.h"
+#include "miner.h"
 #endif
 
 #include <vector>
@@ -38,72 +38,82 @@
 #endif
 
 #ifdef USE_UPNP
- #ifdef WIN32
-  #include <miniupnpc.h>
-  #include <upnpcommands.h>
-  #include <upnperrors.h>
- #else
+#ifdef WIN32
+#include <miniupnpc.h>
+#include <upnpcommands.h>
+#include <upnperrors.h>
+#else
 #include <miniupnpc/miniupnpc.h>
 #include <miniupnpc/upnpcommands.h>
 #include <miniupnpc/upnperrors.h>
- #endif
+#endif
 #endif
 
 using namespace boost;
 
-using std::map;
-using std::string;
-using std::runtime_error;
-using std::vector;
 using std::deque;
+using std::list;
+using std::map;
 using std::max;
 using std::min;
 using std::pair;
-using std::list;
+using std::runtime_error;
 using std::set;
+using std::string;
+using std::vector;
 
-const unsigned int 
-    nStakeMaxAge = 90 * nSecondsPerDay,             //60 * 60 * 24 * 90; // 90 days as full weight
-    nOnedayOfAverageBlocks = (nSecondsPerDay / nStakeTargetSpacing)/10;  // the old 144
-    //nOnedayOfAverageBlocks = nSecondsPerDay / nStakeTargetSpacing;  // should be 144 if it's BTC!
-unsigned int 
-    nStakeMinAge = 30 * nSecondsPerDay,             //60 * 60 * 24 * 30; // 30 days as zero time weight
-    nStakeTargetSpacing = 1 * nSecondsperMinute,    //1 * 60; // 1-minute stake spacing
-// MODIFIER_INTERVAL: time to elapse before new modifier is computed
-//extern unsigned int nModifierInterval;
-    nModifierInterval = 6 * nSecondsPerHour;        //6 * 60 * 60; 
-                        // time (in seconds????)to elapse before new modifier is computed
-                        // i.e 6 hours?????
-                        // or is the INTENT 360 blocks??????????????????
-                        // another way to put it is, WHAT ARE THE UNITS, seconds or blocks??????????
-                        // so I guess it IS seconds, actually 6 hours.
-
-static const int 
-#ifdef WIN32
-    nDEFAULT_BAN_SCORE = 1000,
-    nDEFAULT_BAN_TIME_in_seconds = 3 * nSecondsperMinute;
-#else
-    nDEFAULT_BAN_SCORE = 100,
-    nDEFAULT_BAN_TIME_in_seconds = nHoursPerDay * nSecondsPerHour;  // one day
-#endif
+const unsigned int
+    nStakeMaxAge =
+        90 * nSecondsPerDay, // 60 * 60 * 24 * 90; // 90 days as full weight
+    nOnedayOfAverageBlocks =
+        (nSecondsPerDay / nStakeTargetSpacing) / 10; // the old 144
+// nOnedayOfAverageBlocks = nSecondsPerDay / nStakeTargetSpacing;  // should be
+// 144 if it's BTC!
+unsigned int nStakeMinAge = 30 * nSecondsPerDay, // 60 * 60 * 24 * 30; // 30
+                                                 // days as zero time weight
+    nStakeTargetSpacing =
+        1 * nSecondsperMinute, // 1 * 60; // 1-minute stake spacing
+                               // MODIFIER_INTERVAL: time to elapse before new
+                               // modifier is computed
+                               // extern unsigned int nModifierInterval;
+    nModifierInterval =
+        6 *
+        nSecondsPerHour; // 6 * 60 * 60;
+                         // time (in seconds????)to elapse before new modifier
+                         // is computed i.e 6 hours????? or is the INTENT 360
+                         // blocks?????????????????? another way to put it is,
+                         // WHAT ARE THE UNITS, seconds or blocks?????????? so I
+                         // guess it IS seconds, actually 6 hours.
 
 // WM - static const int MAX_OUTBOUND_CONNECTIONS = 8;
-static const int DEFAULT_MAX_CONNECTIONS        = 125;    // WM - Default value for -maxconnections= parameter.
-static const int MIN_CONNECTIONS                = 8;      // WM - Lowest value we allow for -maxconnections= (never ever set less than 2!).
-static const int MAX_CONNECTIONS                = 1000;   // WM - Max allowed value for -maxconnections= parameter.  Getting kinda excessive, eh?
+static const int DEFAULT_MAX_CONNECTIONS =
+    125; // WM - Default value for -maxconnections= parameter.
+static const int MIN_CONNECTIONS =
+    8; // WM - Lowest value we allow for -maxconnections= (never ever set less
+       // than 2!).
+static const int MAX_CONNECTIONS =
+    1000; // WM - Max allowed value for -maxconnections= parameter.  Getting
+          // kinda excessive, eh?
 
-static const int DEFAULT_OUTBOUND_CONNECTIONS   = 8;      // WM - Reasonable default of 8 outbound connections for -maxoutbound= parameter.
-static const int MIN_OUTBOUND_CONNECTIONS       = 4;      // WM - Lowest we allow for -maxoutbound= parameter shall be 4 connections (never ever set below 2).
-static const int MAX_OUTBOUND_CONNECTIONS       = 100;    // WM - This no longer means what it used to.  Outbound conn count now runtime configurable.
-//static const int MAX_OUTBOUND_CONNECTIONS = 16;
+static const int DEFAULT_OUTBOUND_CONNECTIONS =
+    8; // WM - Reasonable default of 8 outbound connections for -maxoutbound=
+       // parameter.
+static const int MIN_OUTBOUND_CONNECTIONS =
+    4; // WM - Lowest we allow for -maxoutbound= parameter shall be 4
+       // connections (never ever set below 2).
+static const int MAX_OUTBOUND_CONNECTIONS =
+    100; // WM - This no longer means what it used to.  Outbound conn count now
+         // runtime configurable.
+// static const int MAX_OUTBOUND_CONNECTIONS = 16;
 
-void ThreadMessageHandler2(void* parg);
-void ThreadSocketHandler2(void* parg);
-void ThreadOpenConnections2(void* parg);
-void ThreadOpenAddedConnections2(void* parg);
-void ThreadDNSAddressSeed2(void* parg);
+void ThreadMessageHandler2(void *parg);
+void ThreadSocketHandler2(void *parg);
+void ThreadOpenConnections2(void *parg);
+void ThreadOpenAddedConnections2(void *parg);
+void ThreadDNSAddressSeed2(void *parg);
 
-struct LocalServiceInfo {
+struct LocalServiceInfo
+{
     int nScore;
     int nPort;
 };
@@ -119,15 +129,14 @@ static CCriticalSection cs_mapLocalHost;
 static map<CNetAddr, LocalServiceInfo> mapLocalHost;
 static bool vfReachable[NET_MAX] = {};
 static bool vfLimited[NET_MAX] = {};
-static CNode* pnodeLocalHost = NULL;
-static CNode* pnodeSync = NULL;
+static CNode *pnodeLocalHost = NULL;
 CAddress addrSeenByPeer(CService("0.0.0.0", 0), nLocalServices);
 ::uint64_t nLocalHostNonce = 0;
 boost::array<int, THREAD_MAX> vnThreadsRunning;
 static std::vector<SOCKET> vhListenSocket;
 CAddrMan addrman;
 
-vector<CNode*> vNodes;
+vector<CNode *> vNodes;
 vector<std::string> vAddedNodes;
 map<CInv, CDataStream> mapRelay;
 map<CInv, ::int64_t> mapAlreadyAskedFor;
@@ -141,7 +150,14 @@ CCriticalSection cs_vOneShots;
 CCriticalSection cs_setservAddNodeAddresses;
 CCriticalSection cs_vAddedNodes;
 
+NodeId nLastNodeId = 0;
+CCriticalSection cs_nLastNodeId;
+
 static CSemaphore *semOutbound = NULL;
+
+// Signals for message handling
+static CNodeSignals g_signals;
+CNodeSignals& GetNodeSignals() { return g_signals; }
 
 void AddOneShot(string strDest)
 {
@@ -159,13 +175,13 @@ int GetMaxConnections()
     int count;
 
     // Config'eth away..
-    count = GetArg( "-maxconnections", DEFAULT_MAX_CONNECTIONS );
-    
+    count = GetArg("-maxconnections", DEFAULT_MAX_CONNECTIONS);
+
     // Ensure some level of sanity amount the max connection count.
-    count = max( count, MIN_CONNECTIONS );
-    count = min( count, MAX_CONNECTIONS );
-    
-    //printf( "GetMaxConnections() = %d\n", count );
+    count = max(count, MIN_CONNECTIONS);
+    count = min(count, MAX_CONNECTIONS);
+
+    // printf( "GetMaxConnections() = %d\n", count );
 
     return count;
 }
@@ -175,31 +191,20 @@ static int GetMaxOutboundConnections()
     int count;
 
     // What sayeth the config parameters?
-    count = GetArg( "-maxoutbound", DEFAULT_OUTBOUND_CONNECTIONS );
-    
-    // Did someone set it too low or too high?  Shame, shame..
-    count = max( count, MIN_OUTBOUND_CONNECTIONS );
-    count = min( count, MAX_OUTBOUND_CONNECTIONS );
-    count = min( count, GetMaxConnections() );
+    count = GetArg("-maxoutbound", DEFAULT_OUTBOUND_CONNECTIONS);
 
-    //printf( "GetMaxOutboundConnections() = %d\n", count );
-    
+    // Did someone set it too low or too high?  Shame, shame..
+    count = max(count, MIN_OUTBOUND_CONNECTIONS);
+    count = min(count, MAX_OUTBOUND_CONNECTIONS);
+    count = min(count, GetMaxConnections());
+
+    // printf( "GetMaxOutboundConnections() = %d\n", count );
+
     return count;
 }
 
-void CNode::PushGetBlocks(CBlockIndex* pindexBegin, uint256 hashEnd)
-{
-    // Filter out duplicate requests
-    if (pindexBegin == pindexLastGetBlocksBegin && hashEnd == hashLastGetBlocksEnd)
-        return;
-    pindexLastGetBlocksBegin = pindexBegin;
-    hashLastGetBlocksEnd = hashEnd;
-
-    PushMessage("getblocks", CBlockLocator(pindexBegin), hashEnd);
-}
-
 // find 'best' local address for a particular peer
-bool GetLocal(CService& addr, const CNetAddr *paddrPeer)
+bool GetLocal(CService &addr, const CNetAddr *paddrPeer)
 {
     if (fNoListen)
         return false;
@@ -208,18 +213,13 @@ bool GetLocal(CService& addr, const CNetAddr *paddrPeer)
     int nBestReachability = -1;
     {
         LOCK(cs_mapLocalHost);
-        for (
-             map<CNetAddr, LocalServiceInfo>::iterator it = mapLocalHost.begin();
-             it != mapLocalHost.end();
-             ++it
-            )
+        for (map<CNetAddr, LocalServiceInfo>::iterator it = mapLocalHost.begin();
+             it != mapLocalHost.end(); ++it)
         {
             int nScore = (*it).second.nScore;
             int nReachability = (*it).first.GetReachabilityFrom(paddrPeer);
-            if (
-                (nReachability > nBestReachability) ||
-                ((nReachability == nBestReachability) && (nScore > nBestScore))
-               )
+            if ((nReachability > nBestReachability) ||
+                ((nReachability == nBestReachability) && (nScore > nBestScore)))
             {
                 addr = CService((*it).first, (*it).second.nPort);
                 nBestReachability = nReachability;
@@ -233,7 +233,7 @@ bool GetLocal(CService& addr, const CNetAddr *paddrPeer)
 // get best local address for a particular peer as a CAddress
 CAddress GetLocalAddress(const CNetAddr *paddrPeer)
 {
-    CAddress ret(CService("0.0.0.0",0),0);
+    CAddress ret(CService("0.0.0.0", 0), 0);
     CService addr;
     if (GetLocal(addr, paddrPeer))
     {
@@ -244,26 +244,22 @@ CAddress GetLocalAddress(const CNetAddr *paddrPeer)
     return ret;
 }
 
-void
-    clearLocalSocketError( SOCKET hSocket )
+void clearLocalSocketError(SOCKET hSocket)
 {
 #ifdef WIN32
-    int
-        nRet,
-        nRetSize = sizeof( nRet );
-    if ( SOCKET_ERROR == getsockopt(hSocket, SOL_SOCKET, SO_ERROR, (char*)(&nRet), &nRetSize) )
+    int nRet, nRetSize = sizeof(nRet);
+    if (SOCKET_ERROR ==
+        getsockopt(hSocket, SOL_SOCKET, SO_ERROR, (char *)(&nRet), &nRetSize))
     {
-        printf(
-                "getsockopt( SO_ERROR ) failed with error code = %i\n",
-                WSAGetLastError()
-              );
+        printf("getsockopt( SO_ERROR ) failed with error code = %i\n",
+               WSAGetLastError());
     }
 #else
-    // now all the clearLocalSocketError can be unguarded
+                                                                   // now all the clearLocalSocketError can be unguarded
 #endif
 }
 
-bool RecvLine(SOCKET hSocket, string& strLine)
+bool RecvLine(SOCKET hSocket, string &strLine)
 {
     strLine = "";
     while (true)
@@ -286,20 +282,17 @@ bool RecvLine(SOCKET hSocket, string& strLine)
                 return false;
             if (nBytes < 0)
             {
-                int 
-                    nErr = WSAGetLastError();
+                int nErr = WSAGetLastError();
 
                 if (nErr == WSAEMSGSIZE)
                 {
                     continue;
                 }
-                if (
-                    (nErr == WSAEWOULDBLOCK) ||
-                    (nErr == WSAEINTR) ||
-                    (nErr == WSAEINPROGRESS)
-                   )
+                if ((nErr == WSAEWOULDBLOCK) || (nErr == WSAEINTR) ||
+                    (nErr == WSAEINPROGRESS))
                 {
-                    Sleep( nTenMilliseconds );      // needed? Or not? Why? How much? Calculated how? Guess?
+                    Sleep(nTenMilliseconds); // needed? Or not? Why? How much? Calculated
+                                             // how? Guess?
                     continue;
                 }
             }
@@ -314,11 +307,10 @@ bool RecvLine(SOCKET hSocket, string& strLine)
             else
             {
                 // socket error
-                int 
-                    nErr = WSAGetLastError();
+                int nErr = WSAGetLastError();
 
                 printf("recv failed: %d\n", nErr);
-                clearLocalSocketError( hSocket );
+                clearLocalSocketError(hSocket);
                 return false;
             }
         }
@@ -330,15 +322,13 @@ bool RecvLine(SOCKET hSocket, string& strLine)
 void static AdvertizeLocal()
 {
     LOCK(cs_vNodes);
-    BOOST_FOREACH(CNode* pnode, vNodes)
+    BOOST_FOREACH (CNode *pnode, vNodes)
     {
         if (pnode->fSuccessfullyConnected)
         {
             CAddress addrLocal = GetLocalAddress(&pnode->addr);
-            if (
-                addrLocal.IsRoutable() && 
-                ((CService)addrLocal != (CService)pnode->addrLocal)
-               )
+            if (addrLocal.IsRoutable() &&
+                ((CService)addrLocal != (CService)pnode->addrLocal))
             {
                 pnode->PushAddress(addrLocal);
                 pnode->addrLocal = addrLocal;
@@ -356,15 +346,12 @@ void SetReachable(enum Network net, bool fFlag)
 }
 
 // learn a new local address
-bool AddLocal(const CService& addr, int nScore)
+bool AddLocal(const CService &addr, int nScore)
 {
     if (!addr.IsRoutable())
         return false;
 
-    if (
-        !fDiscover &&
-        (nScore < LOCAL_MANUAL)
-       )
+    if (!fDiscover && (nScore < LOCAL_MANUAL))
         return false;
 
     if (IsLimited(addr))
@@ -375,16 +362,11 @@ bool AddLocal(const CService& addr, int nScore)
     {
         LOCK(cs_mapLocalHost);
 
-        bool
-            fAlready = (mapLocalHost.count(addr) > 0);
+        bool fAlready = (mapLocalHost.count(addr) > 0);
 
-        LocalServiceInfo
-            &info = mapLocalHost[addr];
+        LocalServiceInfo &info = mapLocalHost[addr];
 
-        if (
-            (!fAlready) ||
-            (nScore >= info.nScore)
-           )
+        if ((!fAlready) || (nScore >= info.nScore))
         {
             info.nScore = nScore + (fAlready ? 1 : 0);
             info.nPort = addr.GetPort();
@@ -402,7 +384,8 @@ bool AddLocal(const CNetAddr &addr, int nScore)
     return AddLocal(CService(addr, GetListenPort()), nScore);
 }
 
-/** Make a particular network entirely off-limits (no automatic connects to it) */
+/** Make a particular network entirely off-limits (no automatic connects to it)
+ */
 void SetLimited(enum Network net, bool fLimited)
 {
     if (net == NET_UNROUTABLE)
@@ -417,13 +400,10 @@ bool IsLimited(enum Network net)
     return vfLimited[net];
 }
 
-bool IsLimited(const CNetAddr &addr)
-{
-    return IsLimited(addr.GetNetwork());
-}
+bool IsLimited(const CNetAddr &addr) { return IsLimited(addr.GetNetwork()); }
 
 /** vote for a local address */
-bool SeenLocal(const CService& addr)
+bool SeenLocal(const CService &addr)
 {
     {
         LOCK(cs_mapLocalHost);
@@ -438,94 +418,77 @@ bool SeenLocal(const CService& addr)
 }
 
 /** check whether a given address is potentially local */
-bool IsLocal(const CService& addr)
+bool IsLocal(const CService &addr)
 {
     LOCK(cs_mapLocalHost);
     return (mapLocalHost.count(addr) > 0);
 }
 
 /** check whether a given address is in a network we can probably connect to */
-bool IsReachable(const CNetAddr& addr)
+bool IsReachable(const CNetAddr &addr)
 {
     LOCK(cs_mapLocalHost);
 
-    enum Network
-        net = addr.GetNetwork();
+    enum Network net = addr.GetNetwork();
 
     return (vfReachable[net] && !vfLimited[net]);
 }
 
-extern int GetExternalIPbySTUN(::uint64_t rnd, struct sockaddr_in *mapped, const char **srv);
+extern int GetExternalIPbySTUN(::uint64_t rnd, struct sockaddr_in *mapped,
+                               const char **srv);
 
-// We now get our external IP from the IRC server first and only use this as a backup
-bool GetMyExternalIP(CNetAddr& ipRet)
+// We now get our external IP from the IRC server first and only use this as a
+// backup
+bool GetMyExternalIP(CNetAddr &ipRet)
 {
-    struct sockaddr_in 
-        mapped;
+    struct sockaddr_in mapped;
 
-    ::uint64_t 
-        rnd = GetRand(~0LL);
+    ::uint64_t rnd = GetRand(~0LL);
 
-    const char 
-        *srv;
+    const char *srv;
 
-    int 
-        rc = GetExternalIPbySTUN(rnd, &mapped, &srv);
+    int rc = GetExternalIPbySTUN(rnd, &mapped, &srv);
 
-    if(rc >= 0) 
+    if (rc >= 0)
     {
         ipRet = CNetAddr(mapped.sin_addr);
-        printf("GetExternalIPbySTUN(%" PRIu64 ") returned %s in attempt %d; Server=%s\n", 
-                rnd, 
-                ipRet.ToStringIP().c_str(), 
-                rc, 
-                srv
-              );
+        printf("GetExternalIPbySTUN(%" PRIu64
+               ") returned %s in attempt %d; Server=%s\n",
+               rnd, ipRet.ToStringIP().c_str(), rc, srv);
         return true;
     }
     return false;
 }
 
-void ThreadGetMyExternalIP(void* parg)
+void ThreadGetMyExternalIP(void *parg)
 {
     // Make this thread recognisable as the external IP detection thread
     RenameThread("yacoin-ext-ip");
 
-    CNetAddr 
-        addrLocalHost;
+    CNetAddr addrLocalHost;
 
     if (GetMyExternalIP(addrLocalHost))
     {
-        printf("GetMyExternalIP() returned %s\n", addrLocalHost.ToStringIP().c_str());
+        printf("GetMyExternalIP() returned %s\n",
+               addrLocalHost.ToStringIP().c_str());
         AddLocal(addrLocalHost, LOCAL_HTTP);
     }
 }
 
-
-
-
-
-void AddressCurrentlyConnected(const CService& addr)
+void AddressCurrentlyConnected(const CService &addr)
 {
     addrman.Connected(addr);
 }
 
+::uint64_t CNode::nTotalBytesRecv = 0;
+::uint64_t CNode::nTotalBytesSent = 0;
+CCriticalSection CNode::cs_totalBytesRecv;
+CCriticalSection CNode::cs_totalBytesSent;
 
-
-
-::uint64_t 
-    CNode::nTotalBytesRecv = 0;
-::uint64_t 
-    CNode::nTotalBytesSent = 0;
-CCriticalSection 
-    CNode::cs_totalBytesRecv;
-CCriticalSection 
-    CNode::cs_totalBytesSent;
-
-static CNode* FindNode(const CNetAddr& ip)
+static CNode *FindNode(const CNetAddr &ip)
 {
     LOCK(cs_vNodes);
-    BOOST_FOREACH(CNode* pnode, vNodes)
+    BOOST_FOREACH (CNode *pnode, vNodes)
     {
         if ((CNetAddr)pnode->addr == ip)
             return (pnode);
@@ -533,10 +496,10 @@ static CNode* FindNode(const CNetAddr& ip)
     return NULL;
 }
 
-static CNode* FindNode(std::string addrName)
+static CNode *FindNode(std::string addrName)
 {
     LOCK(cs_vNodes);
-    BOOST_FOREACH(CNode* pnode, vNodes)
+    BOOST_FOREACH (CNode *pnode, vNodes)
     {
         if (pnode->addrName == addrName)
             return (pnode);
@@ -544,10 +507,10 @@ static CNode* FindNode(std::string addrName)
     return NULL;
 }
 
-static CNode* FindNode(const CService& addr)
+static CNode *FindNode(const CService &addr)
 {
     LOCK(cs_vNodes);
-    BOOST_FOREACH(CNode* pnode, vNodes)
+    BOOST_FOREACH (CNode *pnode, vNodes)
     {
         if ((CService)pnode->addr == addr)
             return (pnode);
@@ -555,16 +518,16 @@ static CNode* FindNode(const CService& addr)
     return NULL;
 }
 
-CNode* ConnectNode(CAddress addrConnect, const char *pszDest, ::int64_t nTimeout)
+CNode *ConnectNode(CAddress addrConnect, const char *pszDest,
+                   ::int64_t nTimeout)
 {
-    if (pszDest == NULL) 
+    if (pszDest == NULL)
     {
         if (IsLocal(addrConnect))
             return NULL;
 
         // Look for an existing connection
-        CNode
-            * pnode = FindNode((CService)addrConnect);
+        CNode *pnode = FindNode((CService)addrConnect);
 
         if (pnode)
         {
@@ -576,64 +539,61 @@ CNode* ConnectNode(CAddress addrConnect, const char *pszDest, ::int64_t nTimeout
         }
     }
 
-
     /// debug print
     if (fDebug)
     {
-        printf( "trying connection " );
-        if( pszDest )
+        printf("trying connection ");
+        if (pszDest)
         {
-            printf( "%s\n", pszDest );
+            printf("%s\n", pszDest);
         }
         else
         {
-            printf( "%s\n", 
-                strprintf( " %s, last seen = %s",
-                           addrConnect.ToString().c_str(),
-                           ((double)(GetAdjustedTime() - addrConnect.nTime)/3600.0 > 24)?
-                           "days":
-                           strprintf( "%.1lfhrs", 
-                                      (double)(GetAdjustedTime() - addrConnect.nTime)/3600.0
-                                    ).c_str()
-                         ).c_str()
-                  );
-            //printf( "%s lastseen=%.1fhrs\n", addrConnect.ToString().c_str(), (double)(GetAdjustedTime() - addrConnect.nTime)/3600.0 > 24 );
+            printf("%s\n",
+                   strprintf(
+                       " %s, last seen = %s", addrConnect.ToString().c_str(),
+                       ((double)(GetAdjustedTime() - addrConnect.nTime) / 3600.0 > 24)
+                           ? "days"
+                           : strprintf("%.1lfhrs", (double)(GetAdjustedTime() -
+                                                            addrConnect.nTime) /
+                                                       3600.0)
+                                 .c_str())
+                       .c_str());
+            // printf( "%s lastseen=%.1fhrs\n", addrConnect.ToString().c_str(),
+            // (double)(GetAdjustedTime() - addrConnect.nTime)/3600.0 > 24 );
         }
     }
     // Connect
     SOCKET hSocket;
-    if (
-        pszDest ? ConnectSocketByName(
-                                      addrConnect, 
-                                      hSocket, 
-                                      pszDest, 
-                                      GetDefaultPort()
-                                     ) : ConnectSocket(addrConnect, hSocket)
-       )
+    if (pszDest
+            ? ConnectSocketByName(addrConnect, hSocket, pszDest, GetDefaultPort())
+            : ConnectSocket(addrConnect, hSocket))
     {
         addrman.Attempt(addrConnect);
 
         /// debug print
-        printf("connected %s\n", pszDest ? pszDest : addrConnect.ToString().c_str());
+        printf("connected %s\n",
+               pszDest ? pszDest : addrConnect.ToString().c_str());
 
         // Set to non-blocking
 #ifdef WIN32
         u_long nOne = 1;
-        if (SOCKET_ERROR == ioctlsocket(hSocket, FIONBIO, &nOne) )
+        if (SOCKET_ERROR == ioctlsocket(hSocket, FIONBIO, &nOne))
         {
-            printf("ConnectSocket() : ioctlsocket non-blocking setting failed, error %d\n", 
-                    WSAGetLastError()
-                  );
-            clearLocalSocketError( hSocket );
+            printf("ConnectSocket() : ioctlsocket non-blocking setting failed, error "
+                   "%d\n",
+                   WSAGetLastError());
+            clearLocalSocketError(hSocket);
         }
 #else
         if (fcntl(hSocket, F_SETFL, O_NONBLOCK) == SOCKET_ERROR)
-            printf("ConnectSocket() : fcntl non-blocking setting failed, error %d\n", errno);
+            printf("ConnectSocket() : fcntl non-blocking setting failed, error %d\n",
+                   errno);
 #endif
 
         // Add node
-        CNode
-            * pnode = new CNode(hSocket, addrConnect, pszDest ? pszDest : "", false);
+        CNode *pnode =
+            new CNode(hSocket, addrConnect, pszDest ? pszDest : "", false);
 
         if (nTimeout != 0)
             pnode->AddRef(nTimeout);
@@ -656,25 +616,18 @@ CNode* ConnectNode(CAddress addrConnect, const char *pszDest, ::int64_t nTimeout
 
 #ifdef WIN32
 //_____________________________________________________________________________
-char* iGetLastErrorText(DWORD nErrorCode)
+char *iGetLastErrorText(DWORD nErrorCode)
 {
-    char* msg;
+    char *msg;
     // Ask Windows to prepare a standard message for a GetLastError() code:
-    if( 
-        FormatMessageA(
-                       FORMAT_MESSAGE_ALLOCATE_BUFFER | 
-                        FORMAT_MESSAGE_FROM_SYSTEM | 
-                        FORMAT_MESSAGE_IGNORE_INSERTS,
-                        NULL, 
-                        nErrorCode, 
-                        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), 
-                        (LPSTR)&msg, 
-                        0, 
-                        NULL
-                      )
-      ) // OK
+    if (FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER |
+                           FORMAT_MESSAGE_FROM_SYSTEM |
+                           FORMAT_MESSAGE_IGNORE_INSERTS,
+                       NULL, nErrorCode,
+                       MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&msg, 0,
+                       NULL)) // OK
     {
-        return(msg);
+        return (msg);
     }
     else
     {
@@ -688,51 +641,53 @@ void CNode::CloseSocketDisconnect()
     fDisconnect = true;
     if (hSocket != INVALID_SOCKET)
     {
-        int
-            nErr = closesocket(hSocket);
+        int nErr = closesocket(hSocket);
 
-        printf( 
-                "disconnecting node %s", 
-                addrName.c_str()
-              );
-        if( nErr )
-        {   // close socket errored!
+        printf("disconnecting node %s, lastsend = %s, lastrecv = %s, conntime = "
+               "%s, startingheight = %d\n",
+               addrName.c_str(),
+               DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nLastSend).c_str(),
+               DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nLastRecv).c_str(),
+               DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nTimeConnected).c_str(),
+               nStartingHeight);
+        if (nErr)
+        { // close socket errored!
             nErr = WSAGetLastError();
 #ifdef WIN32
-            char
-                *pc = iGetLastErrorText( nErr );
+            char *pc = iGetLastErrorText(nErr);
 
-            switch( nErr )
+            switch (nErr)
             {
-                case WSANOTINITIALISED:
-                    //A successful WSAStartup call must occur before using this function.
+            case WSANOTINITIALISED:
+                // A successful WSAStartup call must occur before using this function.
 
-                case WSAENETDOWN:
-                    //The network subsystem has failed.
+            case WSAENETDOWN:
+                // The network subsystem has failed.
 
-                case WSAENOTSOCK:   //<<<<<<<<<<
-                    //The descriptor is not a socket.
+            case WSAENOTSOCK: //<<<<<<<<<<
+                              // The descriptor is not a socket.
 
-                case WSAEINPROGRESS:
-                    //A blocking Windows Sockets 1.1 call is in progress, or 
-                    //the service provider is still processing a callback function.
+            case WSAEINPROGRESS:
+                // A blocking Windows Sockets 1.1 call is in progress, or
+                // the service provider is still processing a callback function.
 
-                case WSAEINTR:
-                    //The (blocking) Windows Socket 1.1 call was canceled through WSACancelBlockingCall.
+            case WSAEINTR:
+                // The (blocking) Windows Socket 1.1 call was canceled through
+                // WSACancelBlockingCall.
 
-                case WSAEWOULDBLOCK:
-                    //The socket is marked as nonblocking, but the l_onoff
-                    //member of the linger structure is                     :
+            case WSAEWOULDBLOCK:
+                // The socket is marked as nonblocking, but the l_onoff
+                // member of the linger structure is                     :
 
-                    printf( "(%s)", pc );
-                    break;
-                default:
-                    break;
+                printf("(%s)", pc);
+                break;
+            default:
+                break;
             }
 #endif
         }
-        printf( "\n" );
-        clearLocalSocketError( hSocket );
+        printf("\n");
+        clearLocalSocketError(hSocket);
         hSocket = INVALID_SOCKET;
         vRecv.clear();
     }
@@ -741,38 +696,27 @@ void CNode::CloseSocketDisconnect()
     TRY_LOCK(cs_vRecv, lockRecv);
     if (lockRecv)
         vRecv.clear();
-
-    // if this was the sync node, we'll need a new one
-    if (this == pnodeSync)
-        pnodeSync = NULL;
 }
 
-void CNode::Cleanup()
-{
-}
-
+void CNode::Cleanup() {}
 
 void CNode::PushVersion()
 {
     /// when NTP implemented, change to just nTime = GetAdjustedTime()
-    ::int64_t 
-        nTime = (fInbound ? GetAdjustedTime() : GetTime());
+    ::int64_t nTime = (fInbound ? GetAdjustedTime() : GetTime());
 
-    CAddress 
-        addrYou, 
-        addrMe;
+    CAddress addrYou, addrMe;
 
-    bool 
-        fHidden = false;
+    bool fHidden = false;
 
-    if (addr.IsTor()) 
+    if (addr.IsTor())
     {
-        if (mapArgs.count("-torname")) 
+        if (mapArgs.count("-torname"))
         {
             // Our hidden service address
             CService addrTorName(mapArgs["-torname"], GetListenPort());
 
-            if (addrTorName.IsValid()) 
+            if (addrTorName.IsValid())
             {
                 addrYou = addr;
                 addrMe = CAddress(addrTorName);
@@ -781,57 +725,35 @@ void CNode::PushVersion()
         }
     }
 
-    if (!fHidden) 
+    if (!fHidden)
     {
-        addrYou = (
-                    addr.IsRoutable() && !IsProxy(addr) ? 
-                    addr : 
-                    CAddress( CService("0.0.0.0",0) )
-                  );
-        addrMe = GetLocalAddress( &addr );
+        addrYou = (addr.IsRoutable() && !IsProxy(addr)
+                       ? addr
+                       : CAddress(CService("0.0.0.0", 0)));
+        addrMe = GetLocalAddress(&addr);
     }
 
-    RAND_bytes((unsigned char*)&nLocalHostNonce, sizeof(nLocalHostNonce));
-    printf(
-            "\n"
-            "sending version message: version %d, blocks=%d,"
-            "\n"
-            "us=%s, them=%s, peer=%s"
-            "\n"
-            "\n", 
-            PROTOCOL_VERSION, 
-            nBestHeight, 
-            addrMe.ToString().c_str(), 
-            addrYou.ToString().c_str(), 
-            addr.ToString().c_str()
-          );
+    RAND_bytes((unsigned char *)&nLocalHostNonce, sizeof(nLocalHostNonce));
+    printf("\n"
+           "sending version message: version %d, blocks=%d,"
+           "\n"
+           "us=%s, them=%s, peer=%s"
+           "\n"
+           "\n",
+           PROTOCOL_VERSION, chainActive.Height(), addrMe.ToString().c_str(),
+           addrYou.ToString().c_str(), addr.ToString().c_str());
     PushMessage(
-                "version", 
-                PROTOCOL_VERSION, 
-                nLocalServices, 
-                nTime,
-                addrYou, 
-                addrMe,
-                nLocalHostNonce, 
-                FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<string>()), 
-                nBestHeight
-               );
+        "version", PROTOCOL_VERSION, nLocalServices, nTime, addrYou, addrMe,
+        nLocalHostNonce,
+        FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<string>()),
+        chainActive.Height());
 }
 
+std::map<CNetAddr, ::int64_t> CNode::setBanned;
 
+CCriticalSection CNode::cs_setBanned;
 
-
-
-std::map<CNetAddr, ::int64_t> 
-    CNode::setBanned;
-
-CCriticalSection 
-    CNode::cs_setBanned;
-
-void CNode::ClearBanned()
-{
-    setBanned.clear();
-}
+void CNode::ClearBanned() { setBanned.clear(); }
 
 bool CNode::IsBanned(CNetAddr ip)
 {
@@ -839,8 +761,7 @@ bool CNode::IsBanned(CNetAddr ip)
     {
         LOCK(cs_setBanned);
 
-        std::map<CNetAddr, ::int64_t>::iterator 
-            i = setBanned.find(ip);
+        std::map<CNetAddr, ::int64_t>::iterator i = setBanned.find(ip);
 
         if (i != setBanned.end())
         {
@@ -852,44 +773,21 @@ bool CNode::IsBanned(CNetAddr ip)
     return fResult;
 }
 
-bool CNode::Misbehaving(int howmuch)    // banned if banscore  exceeeded
-{
-    if (addr.IsLocal())
+bool CNode::Ban(const CNetAddr &addr) {
+    int64_t banTime = GetTime()+GetArg("-bantime", nDEFAULT_BAN_TIME_in_seconds);  // Default 24-hour ban
     {
-        printf("Warning: Local node %s misbehaving (delta: %d)!\n", addrName.c_str(), howmuch);
-        return false;
+        LOCK(cs_setBanned);
+        if (setBanned[addr] < banTime)
+            setBanned[addr] = banTime;
     }
-
-    nMisbehavior += howmuch;
-    printf("Misbehaving: %s (%d -> %d)",
-            addr.ToString().c_str(), 
-            nMisbehavior-howmuch, 
-            nMisbehavior
-           );
-    if (nMisbehavior >= GetArg("-banscore", nDEFAULT_BAN_SCORE))
-    {
-      //::int64_t banTime = GetTime()+GetArg("-bantime", 60*60*24);  // Default 24-hour ban
-                                        //YOU CAN MAKE THIS CLEAR WITHOUT A COMMENT!!
-
-        ::int64_t banTime = GetTime()+GetArg("-bantime", nDEFAULT_BAN_TIME_in_seconds);
-
-        printf( " DISCONNECTING" );
-        {
-            LOCK(cs_setBanned);
-            if (setBanned[addr] < banTime)
-                setBanned[addr] = banTime;
-        }
-        CloseSocketDisconnect();
-        return true;
-    }
-    printf( "\n" );
-    return false;
+    return true;
 }
 
 #undef X
 #define X(name) stats.name = name
 void CNode::copyStats(CNodeStats &stats)
 {
+    stats.nodeid = this->GetId();
     X(nServices);
     X(nLastSend);
     X(nLastRecv);
@@ -900,23 +798,12 @@ void CNode::copyStats(CNodeStats &stats)
     X(fInbound);
     X(nReleaseTime);
     X(nStartingHeight);
-    X(nMisbehavior);
     X(nSendBytes);
     X(nRecvBytes);
-    stats.fSyncNode = (this == pnodeSync);
 }
 #undef X
 
-
-
-
-
-
-
-
-
-
-void ThreadSocketHandler(void* parg)
+void ThreadSocketHandler(void *parg)
 {
     // Make this thread recognisable as the networking thread
     RenameThread("yacoin-net");
@@ -927,12 +814,12 @@ void ThreadSocketHandler(void* parg)
         ThreadSocketHandler2(parg);
         --vnThreadsRunning[THREAD_SOCKETHANDLER];
     }
-    catch (std::exception& e) 
+    catch (std::exception &e)
     {
         --vnThreadsRunning[THREAD_SOCKETHANDLER];
         PrintException(&e, "ThreadSocketHandler()");
-    } 
-    catch (...) 
+    }
+    catch (...)
     {
         --vnThreadsRunning[THREAD_SOCKETHANDLER];
         throw; // support pthread_cancel()
@@ -940,50 +827,44 @@ void ThreadSocketHandler(void* parg)
     printf("ThreadSocketHandler exited\n");
 }
 
-static void updatePreviousNodecountIf( 
-                                      vector<CNode*> & vNodes, 
-                                      unsigned int & nPrevNodeCount
-                                     )
+static void updatePreviousNodecountIf(vector<CNode *> &vNodes,
+                                      unsigned int &nPrevNodeCount)
 {
     if (vNodes.size() != nPrevNodeCount)
     {
-        unsigned int
-            nNewSize = (unsigned int)vNodes.size();
-        string
-            sWhichWay = "";
-        if( nPrevNodeCount > nNewSize ) // going down
+        unsigned int nNewSize = (unsigned int)vNodes.size();
+        string sWhichWay = "";
+        if (nPrevNodeCount > nNewSize) // going down
             sWhichWay = "down";
-        if( nPrevNodeCount < nNewSize ) // going up
+        if (nPrevNodeCount < nNewSize) // going up
             sWhichWay = "up";
 
 #ifdef _MSC_VER
-        (void)printf(
-                    "\n"
-                    "connection count %s from %d to %d"
-                    "\n"
-                    "\n"
-                    "", 
-                    sWhichWay.c_str(),
-                    nPrevNodeCount, 
-                    nNewSize
-                   );
+        (void)printf("\n"
+                     "connection count %s from %d to %d"
+                     "\n"
+                     "\n"
+                     "",
+                     sWhichWay.c_str(), nPrevNodeCount, nNewSize);
 #endif
         nPrevNodeCount = nNewSize;
         uiInterface.NotifyNumConnectionsChanged(nNewSize);
-//MB_OK                 0x00000000L The sound specified as the Windows Default Beep sound.
-//MB_ICONSTOP           0x00000010L See MB_ICONERROR.
-//MB_ICONERROR          0x00000010L The sound specified as the Windows Critical Stop sound.
-//MB_ICONHAND           0x00000010L See MB_ICONERROR.
-//MB_ICONQUESTION       0x00000020L The sound specified as the Windows Question sound.
-//MB_ICONWARNING        0x00000030L The sound specified as the Windows Exclamation sound.
-//MB_ICONEXCLAMATION    0x00000030L See MB_ICONWARNING.
-//MB_ICONINFORMATION    0x00000040L The sound specified as the Windows Asterisk sound.
-//MB_ICONASTERISK       0x00000040L See MB_ICONINFORMATION.
-//                      0xFFFFFFFF  A simple beep. If the sound card is not available, the sound is generated using the speaker.
+        // MB_OK                 0x00000000L The sound specified as the Windows
+        // Default Beep sound. MB_ICONSTOP           0x00000010L See MB_ICONERROR.
+        // MB_ICONERROR          0x00000010L The sound specified as the Windows
+        // Critical Stop sound. MB_ICONHAND           0x00000010L See MB_ICONERROR.
+        // MB_ICONQUESTION       0x00000020L The sound specified as the Windows
+        // Question sound. MB_ICONWARNING        0x00000030L The sound specified as
+        // the Windows Exclamation sound. MB_ICONEXCLAMATION    0x00000030L See
+        // MB_ICONWARNING. MB_ICONINFORMATION    0x00000040L The sound specified as
+        // the Windows Asterisk sound. MB_ICONASTERISK       0x00000040L See
+        // MB_ICONINFORMATION.
+        //                      0xFFFFFFFF  A simple beep. If the sound card is not
+        //                      available, the sound is generated using the speaker.
         // unsigned int
-            // nUpSound = MB_ICONINFORMATION,
-            // nDownSound = MB_ICONERROR;
-        if( "down" == sWhichWay )
+        // nUpSound = MB_ICONINFORMATION,
+        // nDownSound = MB_ICONERROR;
+        if ("down" == sWhichWay)
         {
             //(void)MessageBeep( nDownSound );
         }
@@ -991,105 +872,82 @@ static void updatePreviousNodecountIf(
         {
             //(void)MessageBeep( nUpSound );
         }
-        if( "down" == sWhichWay )
+        if ("down" == sWhichWay)
         {
-            if(
-               (0 == nNewSize) 
-               //|| 
-               //(1 == nNewSize) 
-              )
+            if ((0 == nNewSize)
+                //||
+                //(1 == nNewSize)
+            )
             {   // things are pretty bleak, so we could shut down and restart?
                 // just while we are testing
 #ifdef _MSC_VER
-    #ifdef _DEBUG
-                //StartShutdown();
-    #else
-                //StartShutdown();
-    #endif
+#ifdef _DEBUG
+                // StartShutdown();
+#else
+                // StartShutdown();
+#endif
 #endif
             }
         }
     }
 }
 
-
-void ThreadSocketHandler2(void* parg)
+void ThreadSocketHandler2(void *parg)
 {
     printf("ThreadSocketHandler2 started\n");
 
-    list<CNode*> 
-        vNodesDisconnected;
+    list<CNode *> vNodesDisconnected;
 
-    unsigned int 
-        nPrevNodeCount = 0;
-    //const int
-        //nOneMinuteInSeconds = 60,  //nSecondsperMinute
-        //nOneMillisecond = 1,    //
-        //nTenMilliseconds = 10,
-        //nOneHundredMilliseconds = 100;
+    unsigned int nPrevNodeCount = 0;
+    // const int
+    // nOneMinuteInSeconds = 60,  //nSecondsperMinute
+    // nOneMillisecond = 1,    //
+    // nTenMilliseconds = 10,
+    // nOneHundredMilliseconds = 100;
     while (true)
     {
-        if( fDebug )
-            (void)printf( "ThreadSocketHandler2 is looping"
-                          "\n"
-                        );
+        if (fDebug)
+            (void)printf("ThreadSocketHandler2 is looping"
+                         "\n");
         //
         // Disconnect nodes
         //
         {
             LOCK(cs_vNodes);
             // Disconnect unused nodes
-            vector<CNode*> 
-                vNodesCopy = vNodes;
+            vector<CNode *> vNodesCopy = vNodes;
 
-            BOOST_FOREACH(CNode* pnode, vNodesCopy)
+            BOOST_FOREACH (CNode *pnode, vNodesCopy)
             {
-                if (
-                    pnode->fDisconnect ||
-                    (
-                     pnode->GetRefCount() <= 0 && 
-                     pnode->vRecv.empty() && 
-                     pnode->vSend.empty()
-                    )
-                   )
-                {   // remove from vNodes using the standard C++ idiom          
-                    vNodes.erase(                 
-                                 remove(  
-                                        vNodes.begin(), 
-                                        vNodes.end(), 
-                                        pnode
-                                       )
-                                       , 
-                                 vNodes.end()
-                                )
-                                  ;
+                if (pnode->fDisconnect ||
+                    (pnode->GetRefCount() <= 0 && pnode->vRecv.empty() &&
+                     pnode->vSend.empty()))
+                {
+                    // remove from vNodes using the standard C++ idiom
+                    vNodes.erase(remove(vNodes.begin(), vNodes.end(), pnode),
+                                 vNodes.end());
 
                     // release outbound grant (if any)
                     pnode->grantOutbound.Release();
 
+                    printf("(Node %s) Disconnect unused node, pnode->fDisconnect = %d\n",
+                           pnode->addrName.c_str(), pnode->fDisconnect);
                     pnode->CloseSocketDisconnect();
                     pnode->Cleanup();
 
                     // hold in disconnected pool until all refs are released
-                    pnode->nReleaseTime = max(
-                                              pnode->nReleaseTime, 
-                                              GetTime() + (15 * nOneMinuteInSeconds)   // Is it 15 minutes???
-                                                                    // If so, WHY?????????
-                                             );
-
-                    if (                        // what is this testing for, and WHY????
-                        pnode->fNetworkNode || 
-                        pnode->fInbound
-                       )
+                    if ( // what is this testing for, and WHY????
+                        pnode->fNetworkNode || pnode->fInbound)
                         pnode->Release();
                     vNodesDisconnected.push_back(pnode);
                 }
-            //Sleep( nOneMillisecond ); //Sleep( nOneHundredMilliseconds );
+                // Sleep( nOneMillisecond ); //Sleep( nOneHundredMilliseconds );
             }
-
+        }// end of LOCK(cs_vNodes)
+        {
             // Delete disconnected nodes
-            list<CNode*> vNodesDisconnectedCopy = vNodesDisconnected;
-            BOOST_FOREACH(CNode* pnode, vNodesDisconnectedCopy)
+            list<CNode *> vNodesDisconnectedCopy = vNodesDisconnected;
+            BOOST_FOREACH (CNode *pnode, vNodesDisconnectedCopy)
             {
                 // wait until threads are done using it
                 if (pnode->GetRefCount() <= 0)
@@ -1118,25 +976,42 @@ void ThreadSocketHandler2(void* parg)
                         delete pnode;
                     }
                 }
-            //Sleep( nOneMillisecond ); //Sleep( nOneHundredMilliseconds );
+                // Sleep( nOneMillisecond ); //Sleep( nOneHundredMilliseconds );
             }
-            updatePreviousNodecountIf( vNodes, nPrevNodeCount );
-        }   // end of LOCK(cs_vNodes)
+            updatePreviousNodecountIf(vNodes, nPrevNodeCount);
+        }
 
+        // Update median starting height of all connected peers
+        {
+            // Disconnect unused nodes
+            vector<CNode *> vNodesCopy = vNodes;
+
+            if (vNodesCopy.size() > 0)
+            {
+                ::int32_t startingHeight[vNodesCopy.size()];
+                ::int32_t nodeCounter = 0;
+
+                BOOST_FOREACH (CNode *pnode, vNodesCopy)
+                {
+                    startingHeight[nodeCounter] = pnode->nStartingHeight;
+                    nodeCounter++;
+                }
+                std::sort(startingHeight, startingHeight + nodeCounter);
+                nMedianStartingHeight = startingHeight[nodeCounter/2];
+            }
+        }
         //
         // Find which sockets have data to receive
         //
-        const int
-            n50msInMicroseconds = 50000;
-        struct timeval 
-            timeout;
+        const int n50msInMicroseconds = 50000;
+        struct timeval timeout;
 
-        timeout.tv_sec  = 0;
+        timeout.tv_sec = 0;
         timeout.tv_usec = n50msInMicroseconds; // frequency to poll pnode->vSend
-                        // Isn't this the period, not the frequency?
-                        // and why 50,000
+                                               // Isn't this the period, not the
+                                               // frequency? and why 50,000
 
-        fd_set fdsetRecv;   // an array of 64 sockets!
+        fd_set fdsetRecv; // an array of 64 sockets!
         fd_set fdsetSend;
         fd_set fdsetError;
 
@@ -1144,11 +1019,10 @@ void ThreadSocketHandler2(void* parg)
         FD_ZERO(&fdsetSend);
         FD_ZERO(&fdsetError);
         SOCKET
-            hSocketMax = 0;
-        bool
-            have_fds = false;
+        hSocketMax = 0;
+        bool have_fds = false;
 
-        BOOST_FOREACH(SOCKET hListenSocket, vhListenSocket)
+        BOOST_FOREACH (SOCKET hListenSocket, vhListenSocket)
         {
             FD_SET(hListenSocket, &fdsetRecv);
             hSocketMax = max(hSocketMax, hListenSocket);
@@ -1156,7 +1030,7 @@ void ThreadSocketHandler2(void* parg)
         }
         {
             LOCK(cs_vNodes);
-            BOOST_FOREACH(CNode* pnode, vNodes)
+            BOOST_FOREACH (CNode *pnode, vNodes)
             {
                 if (pnode->hSocket == INVALID_SOCKET)
                     continue;
@@ -1167,21 +1041,20 @@ void ThreadSocketHandler2(void* parg)
                 {
                     TRY_LOCK(pnode->cs_vSend, lockSend);
                     if (lockSend && !pnode->vSend.empty())
+                    {
+                        printf("(Node %s) There is a message will be sent to node\n",
+                               pnode->addrName.c_str());
                         FD_SET(pnode->hSocket, &fdsetSend);
+                    }
                 }
-            Sleep( nOneMillisecond ); //nTenMilliseconds );  // try this instead of //Sleep( nOneHundredMilliseconds );
+                Sleep(nOneMillisecond); // nTenMilliseconds );  // try this instead of
+                                        // //Sleep( nOneHundredMilliseconds );
             }
         }
 
         --vnThreadsRunning[THREAD_SOCKETHANDLER];
-        int
-            nSelect = select(
-                             have_fds ? hSocketMax + 1 : 0,
-                             &fdsetRecv,
-                             &fdsetSend,
-                             &fdsetError,
-                             &timeout
-                            );
+        int nSelect = select(have_fds ? hSocketMax + 1 : 0, &fdsetRecv, &fdsetSend,
+                             &fdsetError, &timeout);
         ++vnThreadsRunning[THREAD_SOCKETHANDLER];
         if (fShutdown)
             return;
@@ -1189,8 +1062,7 @@ void ThreadSocketHandler2(void* parg)
         {
             if (have_fds)
             {
-                int
-                    nErr = WSAGetLastError();
+                int nErr = WSAGetLastError();
                 printf("socket select error %d\n", nErr);
 
                 for (unsigned int i = 0; i <= hSocketMax; ++i)
@@ -1198,62 +1070,67 @@ void ThreadSocketHandler2(void* parg)
             }
             FD_ZERO(&fdsetSend);
             FD_ZERO(&fdsetError);
-            Sleep(timeout.tv_usec/nMillisecondsPerSecond);    // what is this sleep amount & what is it for??????
+            Sleep(timeout.tv_usec /
+                  nMillisecondsPerSecond); // what is this sleep amount & what is it
+                                           // for??????
         }
 
         //
         // Accept new connections
         //
-        BOOST_FOREACH(SOCKET hListenSocket, vhListenSocket)
+        BOOST_FOREACH (SOCKET hListenSocket, vhListenSocket)
         {
-            if (hListenSocket != INVALID_SOCKET && FD_ISSET(hListenSocket, &fdsetRecv))
+            if (hListenSocket != INVALID_SOCKET &&
+                FD_ISSET(hListenSocket, &fdsetRecv))
             {
 #ifdef USE_IPV6
                 struct sockaddr_storage sockaddr;
 #else
                 struct sockaddr sockaddr;
 #endif
-                socklen_t
-                    len = sizeof(sockaddr);
+                socklen_t len = sizeof(sockaddr);
 
                 SOCKET
-                    hSocket = accept(hListenSocket, (struct sockaddr*)&sockaddr, &len);
+                hSocket = accept(hListenSocket, (struct sockaddr *)&sockaddr, &len);
 
-                CAddress
-                    addr;
+                CAddress addr;
 
                 if (hSocket != INVALID_SOCKET)
                 {
-                    if (!addr.SetSockAddr((const struct sockaddr*)&sockaddr))
+                    if (!addr.SetSockAddr((const struct sockaddr *)&sockaddr))
                         printf("Warning: Unknown socket family\n");
                 }
 
-                int
-                    nInbound = 0;       // does this mean false? Or something else??
+                int nInbound = 0; // does this mean false? Or something else??
 
                 {
                     LOCK(cs_vNodes);
-                    BOOST_FOREACH(CNode* pnode, vNodes)
+                    BOOST_FOREACH (CNode *pnode, vNodes)
                         if (pnode->fInbound)
                             ++nInbound;
                 }
 
                 if (hSocket == INVALID_SOCKET)
                 {
-                    int
-                        nErr = WSAGetLastError();
+                    int nErr = WSAGetLastError();
 
                     if (nErr != WSAEWOULDBLOCK)
                     {
                         printf("socket error accept failed: %d\n", nErr);
-                        clearLocalSocketError( hSocket );
+                        clearLocalSocketError(hSocket);
                     }
                 }
                 else
                 {
-                  //if (nInbound >= GetArg("-maxconnections", 125) - MAX_OUTBOUND_CONNECTIONS)
-                    if ( nInbound >= GetMaxConnections() - GetMaxOutboundConnections() )
+                    // if (nInbound >= GetArg("-maxconnections", 125) -
+                    // MAX_OUTBOUND_CONNECTIONS)
+                    if (nInbound >= GetMaxConnections() - GetMaxOutboundConnections())
                     {
+                        printf(
+                            "close connection %s due to reaching maximum connection, "
+                            "GetMaxConnections() = %d, GetMaxOutboundConnections() = %d\n",
+                            addr.ToString().c_str(), GetMaxConnections(),
+                            GetMaxOutboundConnections());
                         {
                             LOCK(cs_setservAddNodeAddresses);
                             if (!setservAddNodeAddresses.count(addr))
@@ -1264,18 +1141,19 @@ void ThreadSocketHandler2(void* parg)
                     {
                         if (CNode::IsBanned(addr))
                         {
-                            printf("connection from %s dropped (banned)\n", addr.ToString().c_str());
+                            printf("connection from %s dropped (banned)\n",
+                                   addr.ToString().c_str());
                             (void)closesocket(hSocket);
                         }
                         else
                         {
                             printf("accepted connection %s\n", addr.ToString().c_str());
-                            CNode* pnode = new CNode(hSocket, addr, "", true);
+                            CNode *pnode = new CNode(hSocket, addr, "", true);
                             pnode->AddRef();
                             {
                                 LOCK(cs_vNodes);
                                 vNodes.push_back(pnode);
-                                updatePreviousNodecountIf( vNodes, nPrevNodeCount );
+                                updatePreviousNodecountIf(vNodes, nPrevNodeCount);
                             }
                         }
                     }
@@ -1285,18 +1163,17 @@ void ThreadSocketHandler2(void* parg)
         //
         // Service each socket
         //
-        vector<CNode*>
-            vNodesCopy;
+        vector<CNode *> vNodesCopy;
         {
             LOCK(cs_vNodes);
             vNodesCopy = vNodes;
-            BOOST_FOREACH(CNode* pnode, vNodesCopy)
+            BOOST_FOREACH (CNode *pnode, vNodesCopy)
             {
                 pnode->AddRef();
-                //Sleep( nOneMillisecond );   //nOneHundredMilliseconds );
+                // Sleep( nOneMillisecond );   //nOneHundredMilliseconds );
             }
         }
-        BOOST_FOREACH(CNode* pnode, vNodesCopy)
+        BOOST_FOREACH (CNode *pnode, vNodesCopy)
         {
             if (fShutdown)
                 return;
@@ -1306,43 +1183,43 @@ void ThreadSocketHandler2(void* parg)
             //
             if (pnode->hSocket == INVALID_SOCKET)
                 continue;
-            if (
-                FD_ISSET(pnode->hSocket, &fdsetRecv) ||
-                FD_ISSET(pnode->hSocket, &fdsetError)
-               )
+            if (FD_ISSET(pnode->hSocket, &fdsetRecv) ||
+                FD_ISSET(pnode->hSocket, &fdsetError))
             {
                 TRY_LOCK(pnode->cs_vRecv, lockRecv);
                 if (lockRecv)
                 {
                     LOCK(cs_vNodes);
-        
-                    CDataStream
-                        & vRecv = pnode->vRecv;
 
-                    ::uint64_t 
-                        nPos = vRecv.size();
+                    CDataStream &vRecv = pnode->vRecv;
+
+                    ::uint64_t nPos = vRecv.size();
 
                     if (nPos > ReceiveBufferSize())
                     {
                         if (!pnode->fDisconnect)
-                            printf("socket recv flood control disconnect (%" PRIszu " bytes)\n", 
-                                    vRecv.size()
-                                  );
+                            printf("(Node %s) socket recv flood control disconnect (%" PRIszu
+                                   " bytes)\n",
+                                   pnode->addrName.c_str(), vRecv.size());
+                        printf("(Node %s) Close connection to node due to receive buffer "
+                               "overflow (%" PRIszu " bytes)\n",
+                               pnode->addrName.c_str(), vRecv.size());
                         pnode->CloseSocketDisconnect();
                     }
                     else
                     {
                         // typical socket buffer is 8K-64K
-                        char 
-                            pchBuf[0x10000];   // so what is this, 64K??? WHY??
+                        char pchBuf[0x10000]; // so what is this, 64K??? WHY??
 
-                        int 
-                            nBytes = recv(pnode->hSocket, pchBuf, sizeof(pchBuf), MSG_DONTWAIT);
+                        int nBytes =
+                            recv(pnode->hSocket, pchBuf, sizeof(pchBuf), MSG_DONTWAIT);
 
                         if (nBytes > 0)
                         {
                             vRecv.resize(nPos + nBytes);
                             memcpy(&vRecv[nPos], pchBuf, nBytes);
+                            printf("(Node %s) Received %d bytes from node\n",
+                                   pnode->addrName.c_str(), nBytes);
                             pnode->nLastRecv = GetTime();
                             pnode->nRecvBytes += nBytes;
                             pnode->RecordBytesRecv(nBytes);
@@ -1350,191 +1227,200 @@ void ThreadSocketHandler2(void* parg)
                         else
                         {
                             if (nBytes == 0)
-                            {   // socket closed gracefully
+                            { // socket closed gracefully
                                 if (!pnode->fDisconnect)
                                     printf("socket closed\n");
+                                printf("(Node %s) Close connection to node gracefully (closed "
+                                       "from remote)\n",
+                                       pnode->addrName.c_str());
                                 pnode->CloseSocketDisconnect();
                             }
                             else
                             {
                                 if (nBytes < 0) // MUST THIS BE THE CASE????
-                                {   // error
-                                    if( SOCKET_ERROR != nBytes )
+                                {               // error
+                                    if (SOCKET_ERROR != nBytes)
                                     {
                                         // now here we have something really interesting!
                                         printf("socket recv return error code %d\n", nBytes);
                                     }
-                                    int 
-                                        nErr = WSAGetLastError();
+                                    int nErr = WSAGetLastError();
 
-                                    if (
-                                        nErr != WSAEWOULDBLOCK && 
-                                                    //The socket is marked as nonblocking and the 
-                                                    //receive operation would block.
+                                    if (nErr != WSAEWOULDBLOCK &&
+                                        // The socket is marked as nonblocking and the
+                                        // receive operation would block.
 
-                                        nErr != WSAEMSGSIZE && 
-                                                    //The message was too large to fit into the 
-                                                    //specified buffer and was truncated.
+                                        nErr != WSAEMSGSIZE &&
+                                        // The message was too large to fit into the
+                                        // specified buffer and was truncated.
 
-                                        nErr != WSAEINTR && 
-                                                    //The (blocking) call was canceled through 
-                                                    //WSACancelBlockingCall.
+                                        nErr != WSAEINTR &&
+                                        // The (blocking) call was canceled through
+                                        // WSACancelBlockingCall.
 
                                         nErr != WSAEINPROGRESS
-                                                    //A blocking Windows Sockets 1.1 call 
-                                                    //is in progress, or the service provider 
-                                                    //is still processing a callback function.
-                                       )
+                                        // A blocking Windows Sockets 1.1 call
+                                        // is in progress, or the service provider
+                                        // is still processing a callback function.
+                                    )
                                     {
-                                        if (!pnode->fDisconnect)    //socket recv error 10054
+                                        if (!pnode->fDisconnect) // socket recv error 10054
                                         {
 #ifdef WIN32
-                                            printf(
-                                                    "socket recv error %d (%s)\n", 
-                                                    nErr
-                                                    , iGetLastErrorText( nErr )
-                                                  ); //<<<<<<<<<<<<<<<<<< this was the only unguarded
+                                            printf("socket recv error %d (%s)\n", nErr,
+                                                   iGetLastErrorText(nErr)); //<<<<<<<<<<<<<<<<<< this
+                                                                             //was the only unguarded
                                             // these are the error codes that cause a disconnect
-                                            switch( nErr )
+                                            switch (nErr)
                                             {
-                                                case WSANOTINITIALISED:
-                                                    //A successful WSAStartup call must occur 
-                                                    //before using this function.
+                                            case WSANOTINITIALISED:
+                                                // A successful WSAStartup call must occur
+                                                // before using this function.
 
-                                                case WSAENETDOWN:
-                                                    //The network subsystem has failed.
+                                            case WSAENETDOWN:
+                                                // The network subsystem has failed.
 
-                                                case WSAEFAULT:
-                                                    //The buf parameter is not completely contained in a 
-                                                    //valid part of the user address space.
+                                            case WSAEFAULT:
+                                                // The buf parameter is not completely contained in a
+                                                // valid part of the user address space.
 
-                                                case WSAENOTCONN:
-                                                    //The socket is not connected.
+                                            case WSAENOTCONN:
+                                                // The socket is not connected.
 
-                                                case WSAENETRESET:
-                                                    //For a connection-oriented socket, 
-                                                    //this error indicates that the connection 
-                                                    //has been broken due to keep-alive activity 
-                                                    //that detected a failure while the operation 
-                                                    //was in progress. For a datagram socket, 
-                                                    //this error indicates that the time to live 
-                                                    //has expired.
+                                            case WSAENETRESET:
+                                                // For a connection-oriented socket,
+                                                // this error indicates that the connection
+                                                // has been broken due to keep-alive activity
+                                                // that detected a failure while the operation
+                                                // was in progress. For a datagram socket,
+                                                // this error indicates that the time to live
+                                                // has expired.
 
-                                                case WSAENOTSOCK:   //<<<<<<<<
-                                                    //The descriptor is not a socket.
+                                            case WSAENOTSOCK: //<<<<<<<<
+                                                              // The descriptor is not a socket.
 
-                                                case WSAEOPNOTSUPP:
-                                                    //MSG_OOB was specified, but the socket 
-                                                    //is not stream-style such as type SOCK_STREAM, 
-                                                    //OOB data is not supported in the communication 
-                                                    //domain associated with this socket, 
-                                                    //or the socket is unidirectional and supports 
-                                                    //only send operations.
+                                            case WSAEOPNOTSUPP:
+                                                // MSG_OOB was specified, but the socket
+                                                // is not stream-style such as type SOCK_STREAM,
+                                                // OOB data is not supported in the communication
+                                                // domain associated with this socket,
+                                                // or the socket is unidirectional and supports
+                                                // only send operations.
 
-                                                case WSAESHUTDOWN:
-                                                    //The socket has been shut down; it is not 
-                                                    //possible to receive on a socket after shutdown 
-                                                    //has been invoked with how set to SD_RECEIVE 
-                                                    //or SD_BOTH.
+                                            case WSAESHUTDOWN:
+                                                // The socket has been shut down; it is not
+                                                // possible to receive on a socket after shutdown
+                                                // has been invoked with how set to SD_RECEIVE
+                                                // or SD_BOTH.
 
-                                                case WSAEINVAL:
-                                                    //The socket has not been bound with bind, 
-                                                    //or an unknown flag was specified, 
-                                                    //or MSG_OOB was specified for a socket 
-                                                    //with SO_OOBINLINE enabled or (for byte 
-                                                    //stream sockets only) len was zero or negative.
+                                            case WSAEINVAL:
+                                                // The socket has not been bound with bind,
+                                                // or an unknown flag was specified,
+                                                // or MSG_OOB was specified for a socket
+                                                // with SO_OOBINLINE enabled or (for byte
+                                                // stream sockets only) len was zero or negative.
 
-                                                case WSAECONNABORTED:
-                                                    //The virtual circuit was terminated due to 
-                                                    //a time-out or other failure. The application 
-                                                    //should close the socket as it is no longer usable.
+                                            case WSAECONNABORTED:
+                                                // The virtual circuit was terminated due to
+                                                // a time-out or other failure. The application
+                                                // should close the socket as it is no longer usable.
 
-                                                case WSAETIMEDOUT:
-                                                    //The connection has been dropped because of a 
-                                                    //network failure or because the peer system 
-                                                    //failed to respond.
+                                            case WSAETIMEDOUT:
+                                                // The connection has been dropped because of a
+                                                // network failure or because the peer system
+                                                // failed to respond.
 
-                                                case WSAECONNRESET:
-                                                    //The virtual circuit was reset by 
-                                                    //the remote side executing a hard or 
-                                                    //abortive close. The application should 
-                                                    //close the socket as it is no longer usable. 
-                                                    //On a UDP-datagram socket, this error would 
-                                                    //indicate that a previous send operation 
-                                                    //resulted in an ICMP "Port Unreachable" message.
+                                            case WSAECONNRESET:
+                                                // The virtual circuit was reset by
+                                                // the remote side executing a hard or
+                                                // abortive close. The application should
+                                                // close the socket as it is no longer usable.
+                                                // On a UDP-datagram socket, this error would
+                                                // indicate that a previous send operation
+                                                // resulted in an ICMP "Port Unreachable" message.
 
-                                                    // this is an error that does happen
+                                                // this is an error that does happen
 
-                                                    break;
-                                                default:
-                                                    break;
+                                                break;
+                                            default:
+                                                break;
                                             }
 #endif
                                         }
+                                        printf("(Node %s) Close connection to node due to error "
+                                               "code = %d (%s)\n",
+                                               pnode->addrName.c_str(), nErr, strerror(nErr));
                                         pnode->CloseSocketDisconnect();
                                     }
                                     // the implication here is
-                                    //else
+                                    // else
                                     //{
                                     //    continue as if nothing happened?
 
                                     // these are the error codes that cause a disconnect
                                     /***************************
-                                    WSANOTINITIALISED //A successful WSAStartup call must occur 
-                                                      //before using this function.
-                                    
-                                    WSAENETDOWN //The network subsystem has failed.
+                  WSANOTINITIALISED //A successful WSAStartup call must occur
+                                    //before using this function.
 
-                                    WSAEFAULT   //The buf parameter is not completely contained in a 
-                                                //valid part of the user address space.
+                  WSAENETDOWN //The network subsystem has failed.
 
-                                    WSAENOTCONN //The socket is not connected.
+                  WSAEFAULT   //The buf parameter is not completely contained in
+                  a
+                              //valid part of the user address space.
+
+                  WSAENOTCONN //The socket is not connected.
 
 
-                                    WSAENETRESET    //For a connection-oriented socket, 
-                                                    //this error indicates that the connection 
-                                                    //has been broken due to keep-alive activity 
-                                                    //that detected a failure while the operation 
-                                                    //was in progress. For a datagram socket, 
-                                                    //this error indicates that the time to live 
-                                                    //has expired.
+                  WSAENETRESET    //For a connection-oriented socket,
+                                  //this error indicates that the connection
+                                  //has been broken due to keep-alive activity
+                                  //that detected a failure while the operation
+                                  //was in progress. For a datagram socket,
+                                  //this error indicates that the time to live
+                                  //has expired.
 
-                                    WSAENOTSOCK     //The descriptor is not a socket. <<<<<<<<<<<
+                  WSAENOTSOCK     //The descriptor is not a socket. <<<<<<<<<<<
 
-                                    WSAEOPNOTSUPP   //MSG_OOB was specified, but the socket 
-                                                    //is not stream-style such as type SOCK_STREAM, 
-                                                    //OOB data is not supported in the communication 
-                                                    //domain associated with this socket, 
-                                                    //or the socket is unidirectional and supports 
-                                                    //only send operations.
+                  WSAEOPNOTSUPP   //MSG_OOB was specified, but the socket
+                                  //is not stream-style such as type
+                  SOCK_STREAM,
+                                  //OOB data is not supported in the
+                  communication
+                                  //domain associated with this socket,
+                                  //or the socket is unidirectional and supports
+                                  //only send operations.
 
-                                    WSAESHUTDOWN    //The socket has been shut down; it is not 
-                                                    //possible to receive on a socket after shutdown 
-                                                    //has been invoked with how set to SD_RECEIVE 
-                                                    //or SD_BOTH.
+                  WSAESHUTDOWN    //The socket has been shut down; it is not
+                                  //possible to receive on a socket after
+                  shutdown
+                                  //has been invoked with how set to SD_RECEIVE
+                                  //or SD_BOTH.
 
-                                    WSAEINVAL       //The socket has not been bound with bind, 
-                                                    //or an unknown flag was specified, 
-                                                    //or MSG_OOB was specified for a socket 
-                                                    //with SO_OOBINLINE enabled or (for byte 
-                                                    //stream sockets only) len was zero or negative.
+                  WSAEINVAL       //The socket has not been bound with bind,
+                                  //or an unknown flag was specified,
+                                  //or MSG_OOB was specified for a socket
+                                  //with SO_OOBINLINE enabled or (for byte
+                                  //stream sockets only) len was zero or
+                  negative.
 
-                                    WSAECONNABORTED //The virtual circuit was terminated due to 
-                                                    //a time-out or other failure. The application 
-                                                    //should close the socket as it is no longer usable.
+                  WSAECONNABORTED //The virtual circuit was terminated due to
+                                  //a time-out or other failure. The application
+                                  //should close the socket as it is no longer
+                  usable.
 
-                                    WSAETIMEDOUT    //The connection has been dropped because of a 
-                                                    //network failure or because the peer system 
-                                                    //failed to respond.
+                  WSAETIMEDOUT    //The connection has been dropped because of a
+                                  //network failure or because the peer system
+                                  //failed to respond.
 
-                                    WSAECONNRESET   //The virtual circuit was reset by 
-                                                    //the remote side executing a hard or 
-                                                    //abortive close. The application should 
-                                                    //close the socket as it is no longer usable. 
-                                                    //On a UDP-datagram socket, this error would 
-                                                    //indicate that a previous send operation 
-                                                    //resulted in an ICMP "Port Unreachable" message.
-                                    ***************************/
+                  WSAECONNRESET   //The virtual circuit was reset by
+                                  //the remote side executing a hard or
+                                  //abortive close. The application should
+                                  //close the socket as it is no longer usable.
+                                  //On a UDP-datagram socket, this error would
+                                  //indicate that a previous send operation
+                                  //resulted in an ICMP "Port Unreachable"
+                  message.
+                  ***************************/
                                     //}
                                 }
                             }
@@ -1555,12 +1441,15 @@ void ThreadSocketHandler2(void* parg)
                 {
                     LOCK(cs_vNodes);
 
-                    CDataStream& vSend = pnode->vSend;
+                    CDataStream &vSend = pnode->vSend;
                     if (!vSend.empty())
                     {
-                        int nBytes = send(pnode->hSocket, &vSend[0], vSend.size(), MSG_NOSIGNAL | MSG_DONTWAIT);
+                        int nBytes = send(pnode->hSocket, &vSend[0], vSend.size(),
+                                          MSG_NOSIGNAL | MSG_DONTWAIT);
                         if (nBytes > 0)
                         {
+                            printf("(Node %s) Sending successfully nBytes = %d\n",
+                                   pnode->addrName.c_str(), nBytes);
                             vSend.erase(vSend.begin(), vSend.begin() + nBytes);
                             pnode->nLastSend = GetTime();
                             pnode->nSendBytes += nBytes;
@@ -1570,15 +1459,14 @@ void ThreadSocketHandler2(void* parg)
                         {
                             // error
                             int nErr = WSAGetLastError();
-                            if (
-                                (nErr != WSAEWOULDBLOCK) && 
-                                (nErr != WSAEMSGSIZE) && 
-                                (nErr != WSAEINTR) && 
-                                (nErr != WSAEINPROGRESS)
-                               )
+                            printf("(Node %s) Sending failed with error code = %d (%s)\n",
+                                   pnode->addrName.c_str(), nErr, strerror(nErr));
+                            if ((nErr != WSAEWOULDBLOCK) && (nErr != WSAEMSGSIZE) &&
+                                (nErr != WSAEINTR) && (nErr != WSAEINPROGRESS))
                             {
-                                printf("socket send error %d\n", nErr);
-                                clearLocalSocketError( pnode->hSocket );
+                                printf("(Node %s) socket send error %d\n",
+                                       pnode->addrName.c_str(), nErr);
+                                clearLocalSocketError(pnode->hSocket);
                                 pnode->CloseSocketDisconnect();
                             }
                         }
@@ -1593,33 +1481,38 @@ void ThreadSocketHandler2(void* parg)
                 LOCK(cs_vNodes);
 
                 if (pnode->vSend.empty())
+                {
                     pnode->nLastSendEmpty = GetTime();
-              //if ((GetTime() - pnode->nTimeConnected) > 60) // what is this here? Seconds??  Why???
-                if ((GetTime() - pnode->nTimeConnected) > 3 * nOneMinuteInSeconds) // test<<<<<<<<<<< try 3 minutes
+                }
+                // if ((GetTime() - pnode->nTimeConnected) > 60) // what is this here?
+                // Seconds??  Why???
+                if ((GetTime() - pnode->nTimeConnected) >
+                    3 * nOneMinuteInSeconds) // test<<<<<<<<<<< try 3 minutes
                 {
                     if (pnode->nLastRecv == 0 || pnode->nLastSend == 0)
                     {
-                        printf("socket no message in first 60 seconds, %d %d\n", 
-                               pnode->nLastRecv != 0, 
-                               pnode->nLastSend != 0
-                              );
+                        printf("(Node %s) socket no message in first 60 seconds, %d %d\n",
+                               pnode->addrName.c_str(), pnode->nLastRecv != 0,
+                               pnode->nLastSend != 0);
                         pnode->fDisconnect = true;
                     }
                     else
                     {
-                        if (
-                            GetTime() - pnode->nLastSend > (90 * 60) &&     // OK, what are these magic #s???
-                            GetTime() - pnode->nLastSendEmpty > (90 * 60)   // "
-                            )
+                        if (GetTime() - pnode->nLastSend >
+                                (90 * 60) &&                              // OK, what are these magic #s???
+                            GetTime() - pnode->nLastSendEmpty > (90 * 60) // "
+                        )
                         {
-                            printf("socket not sending\n");
+                            printf("(Node %s) socket not sending\n", pnode->addrName.c_str());
                             pnode->fDisconnect = true;
                         }
-                        else 
+                        else
                         {
-                            if (GetTime() - pnode->nLastRecv > (90 * 60))  // is this 90 minutes?
+                            if (GetTime() - pnode->nLastRecv >
+                                (90 * 60)) // is this 90 minutes?
                             {
-                                printf("socket inactivity timeout\n");
+                                printf("(Node %s) socket inactivity timeout\n",
+                                       pnode->addrName.c_str());
                                 pnode->fDisconnect = true;
                             }
                         }
@@ -1629,25 +1522,25 @@ void ThreadSocketHandler2(void* parg)
         }
         {
             LOCK(cs_vNodes);
-            BOOST_FOREACH(CNode* pnode, vNodesCopy)
+            BOOST_FOREACH (CNode *pnode, vNodesCopy)
             {
                 pnode->Release();
-                //Sleep( nOneMillisecond );   //nOneHundredMilliseconds );
+                // Sleep( nOneMillisecond );   //nOneHundredMilliseconds );
             }
         }
-        Sleep( 2* nMillisecondsPerSecond ); 
+        Sleep(2 * nMillisecondsPerSecond);
     }
 }
 
 #ifdef USE_UPNP
-void ThreadMapPort2(void* parg)
+void ThreadMapPort2(void *parg)
 {
     printf("ThreadMapPort started\n");
 
     std::string port = strprintf("%u", GetListenPort());
-    const char * multicastif = 0;
-    const char * minissdpdpath = 0;
-    struct UPNPDev * devlist = 0;
+    const char *multicastif = 0;
+    const char *minissdpdpath = 0;
+    struct UPNPDev *devlist = 0;
     char lanaddr[64];
 
 #ifndef UPNPDISCOVER_SUCCESS
@@ -1666,14 +1559,16 @@ void ThreadMapPort2(void* parg)
     r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr));
     if (r == 1)
     {
-        if (fDiscover) {
+        if (fDiscover)
+        {
             char externalIPAddress[40];
-            r = UPNP_GetExternalIPAddress(urls.controlURL, data.first.servicetype, externalIPAddress);
-            if(r != UPNPCOMMAND_SUCCESS)
+            r = UPNP_GetExternalIPAddress(urls.controlURL, data.first.servicetype,
+                                          externalIPAddress);
+            if (r != UPNPCOMMAND_SUCCESS)
                 printf("UPnP: GetExternalIPAddress() returned %d\n", r);
             else
             {
-                if(externalIPAddress[0])
+                if (externalIPAddress[0])
                 {
                     printf("UPnP: ExternalIPAddress = %s\n", externalIPAddress);
                     AddLocal(CNetAddr(externalIPAddress), LOCAL_UPNP);
@@ -1687,16 +1582,18 @@ void ThreadMapPort2(void* parg)
 #ifndef UPNPDISCOVER_SUCCESS
         /* miniupnpc 1.5 */
         r = UPNP_AddPortMapping(urls.controlURL, data.first.servicetype,
-                            port.c_str(), port.c_str(), lanaddr, strDesc.c_str(), "TCP", 0);
+                                port.c_str(), port.c_str(), lanaddr,
+                                strDesc.c_str(), "TCP", 0);
 #else
         /* miniupnpc 1.6 */
         r = UPNP_AddPortMapping(urls.controlURL, data.first.servicetype,
-                            port.c_str(), port.c_str(), lanaddr, strDesc.c_str(), "TCP", 0, "0");
+                                port.c_str(), port.c_str(), lanaddr,
+                                strDesc.c_str(), "TCP", 0, "0");
 #endif
 
-        if(r!=UPNPCOMMAND_SUCCESS)
+        if (r != UPNPCOMMAND_SUCCESS)
             printf("AddPortMapping(%s, %s, %s) failed with code %d (%s)\n",
-                port.c_str(), port.c_str(), lanaddr, r, strupnperror(r));
+                   port.c_str(), port.c_str(), lanaddr, r, strupnperror(r));
         else
             printf("UPnP Port Mapping successful.\n");
         int i = 1;
@@ -1704,9 +1601,11 @@ void ThreadMapPort2(void* parg)
         {
             if (fShutdown || !fUseUPnP)
             {
-                r = UPNP_DeletePortMapping(urls.controlURL, data.first.servicetype, port.c_str(), "TCP", 0);
+                r = UPNP_DeletePortMapping(urls.controlURL, data.first.servicetype,
+                                           port.c_str(), "TCP", 0);
                 printf("UPNP_DeletePortMapping() returned : %d\n", r);
-                freeUPNPDevlist(devlist); devlist = 0;
+                freeUPNPDevlist(devlist);
+                devlist = 0;
                 FreeUPNPUrls(&urls);
                 return;
             }
@@ -1715,25 +1614,31 @@ void ThreadMapPort2(void* parg)
 #ifndef UPNPDISCOVER_SUCCESS
                 /* miniupnpc 1.5 */
                 r = UPNP_AddPortMapping(urls.controlURL, data.first.servicetype,
-                                    port.c_str(), port.c_str(), lanaddr, strDesc.c_str(), "TCP", 0);
+                                        port.c_str(), port.c_str(), lanaddr,
+                                        strDesc.c_str(), "TCP", 0);
 #else
                 /* miniupnpc 1.6 */
                 r = UPNP_AddPortMapping(urls.controlURL, data.first.servicetype,
-                                    port.c_str(), port.c_str(), lanaddr, strDesc.c_str(), "TCP", 0, "0");
+                                        port.c_str(), port.c_str(), lanaddr,
+                                        strDesc.c_str(), "TCP", 0, "0");
 #endif
 
-                if(r!=UPNPCOMMAND_SUCCESS)
+                if (r != UPNPCOMMAND_SUCCESS)
                     printf("AddPortMapping(%s, %s, %s) failed with code %d (%s)\n",
-                        port.c_str(), port.c_str(), lanaddr, r, strupnperror(r));
+                           port.c_str(), port.c_str(), lanaddr, r, strupnperror(r));
                 else
-                    printf("UPnP Port Mapping successful.\n");;
+                    printf("UPnP Port Mapping successful.\n");
+                ;
             }
             Sleep(2000);
             i++;
         }
-    } else {
+    }
+    else
+    {
         printf("No valid UPnP IGDs found\n");
-        freeUPNPDevlist(devlist); devlist = 0;
+        freeUPNPDevlist(devlist);
+        devlist = 0;
         if (r != 0)
             FreeUPNPUrls(&urls);
         while (true)
@@ -1745,7 +1650,7 @@ void ThreadMapPort2(void* parg)
     }
 }
 
-void ThreadMapPort(void* parg)
+void ThreadMapPort(void *parg)
 {
     // Make this thread recognisable as the UPnP thread
     RenameThread("yacoin-UPnP");
@@ -1756,7 +1661,7 @@ void ThreadMapPort(void* parg)
         ThreadMapPort2(parg);
         vnThreadsRunning[THREAD_UPNP]--;
     }
-    catch (std::exception& e)
+    catch (std::exception &e)
     {
         vnThreadsRunning[THREAD_UPNP]--;
         PrintException(&e, "ThreadMapPort()");
@@ -1768,7 +1673,6 @@ void ThreadMapPort(void* parg)
     }
     printf("ThreadMapPort exited\n");
 }
-
 
 void MapPort()
 {
@@ -1795,11 +1699,11 @@ static const char *strDNSSeed[][2] = {
 #ifdef _MSC_VER
     "", ""
 #else
-    //{"yacoin.org", "seed.yacoin.org"},
-#endif    //{"yacoin.org", "seed.yacoin.org"},
+//{"yacoin.org", "seed.yacoin.org"},
+#endif //{"yacoin.org", "seed.yacoin.org"},
 };
 
-void ThreadDNSAddressSeed(void* parg)
+void ThreadDNSAddressSeed(void *parg)
 {
     // Make this thread recognisable as the DNS seeding thread
     RenameThread("yacoin-dnsseed");
@@ -1810,12 +1714,12 @@ void ThreadDNSAddressSeed(void* parg)
         ThreadDNSAddressSeed2(parg);
         --vnThreadsRunning[THREAD_DNSSEED];
     }
-    catch (std::exception& e) 
+    catch (std::exception &e)
     {
         --vnThreadsRunning[THREAD_DNSSEED];
         PrintException(&e, "ThreadDNSAddressSeed()");
-    } 
-    catch (...) 
+    }
+    catch (...)
     {
         --vnThreadsRunning[THREAD_DNSSEED];
         throw; // support pthread_cancel()
@@ -1823,7 +1727,7 @@ void ThreadDNSAddressSeed(void* parg)
     printf("ThreadDNSAddressSeed exited\n");
 }
 
-void ThreadDNSAddressSeed2(void* parg)
+void ThreadDNSAddressSeed2(void *parg)
 {
     printf("ThreadDNSAddressSeed2 started\n");
     int found = 0;
@@ -1831,28 +1735,31 @@ void ThreadDNSAddressSeed2(void* parg)
     if (!fTestNet)
     {
         printf("Loading addresses from DNS seeds (could take a while)\n");
-        
-        size_t
-            Length = ARRAYLEN(strDNSSeed);
 
-      //for (unsigned int seed_idx = 0; seed_idx < ARRAYLEN(strDNSSeed); seed_idx++) 
-        for (unsigned int seed_idx = 0; seed_idx < Length; ++seed_idx) 
+        size_t Length = ARRAYLEN(strDNSSeed);
+
+        // for (unsigned int seed_idx = 0; seed_idx < ARRAYLEN(strDNSSeed);
+        // seed_idx++)
+        for (unsigned int seed_idx = 0; seed_idx < Length; ++seed_idx)
         {
-            if (HaveNameProxy()) 
+            if (HaveNameProxy())
             {
                 AddOneShot(strDNSSeed[seed_idx][1]);
-            } 
-            else 
+            }
+            else
             {
                 vector<CNetAddr> vaddr;
                 vector<CAddress> vAdd;
                 if (LookupHost(strDNSSeed[seed_idx][1], vaddr))
                 {
-                    BOOST_FOREACH(CNetAddr& ip, vaddr)
+                    BOOST_FOREACH (CNetAddr &ip, vaddr)
                     {
-                        int nOneDay = 24*3600;
+                        int nOneDay = 24 * 3600;
                         CAddress addr = CAddress(CService(ip, GetDefaultPort()));
-                        addr.nTime = GetTime() - 3*nOneDay - GetRand(4*nOneDay); // use a random age between 3 and 7 days old
+                        addr.nTime =
+                            GetTime() - 3 * nOneDay -
+                            GetRand(4 *
+                                    nOneDay); // use a random age between 3 and 7 days old
                         vAdd.push_back(addr);
                         ++found;
                     }
@@ -1865,88 +1772,107 @@ void ThreadDNSAddressSeed2(void* parg)
     printf("%d addresses found from DNS seeds\n", found);
 }
 
+// YACOIN TODO update seeds
+::uint32_t pnSeed[] = {
+    0x555b7158, 0x8ef3dfdd, 0x276a5248, 0xcda67076, 0x36c4515f, 0x4ad54bb8,
+    0x913e884f, 0x3829c6c3, 0x78fda1d8, 0xc0d97550, 0x1cd138b7, 0xb9e18377,
+    0x18407076, 0x028b77b6, 0xb2e3344e, 0xc0fd6605, 0xa42a7d0e, 0x666e8e71,
+    0xbddf4bda, 0xe7d1d3d5, 0x228f02af, 0x36485e71, 0x132a1418, 0x30375665,
+    0x72c0e662, 0x31542551, 0x9ed1dd0e, 0xb285f355, 0x75815e31, 0x555b21be,
+    0x376b045e, 0x0f04a4cd, 0x7cc4a17b, 0x1b82e5c5, 0x77037b70, 0xadeb856c,
+    0x64e1fdb2, 0x360460d0, 0x363c03da, 0x357de072, 0x6519d25b, 0xd894437a,
+    0x33f1c851, 0x0c3c0a2e, 0x475a565d, 0xb163526e, 0xd3857247, 0x93b3fa76,
+    0x0c267977, 0xd640bccf, 0x15b057cb, 0x6f782942, 0x15e4d4de, 0x03720205,
+    0xbcd1048e, 0x0242d80c, 0xc2f25a75, 0x09e13aad, 0x5b8c587a, 0x6851995a,
+    0x9deaf7de, 0x93508bae, 0x71cd32c3, 0xe9eb856c, 0x6783223b, 0x4aba54c6,
+    0xe4abbfde, 0x4c4e03b7, 0x1ee0fd74, 0x2b382753, 0x63218977, 0x9ab8cd71,
+    0x2a8703b9, 0xfa75ae52, 0xcefe4771, 0x026ea2dc, 0x02754e4d, 0x6a2dd53a,
+    0x5dabf2de, 0x0cb08dca, 0x99798459, 0x1d2e597c, 0xa430203b, 0x64c34b25,
+    0x237ab751, 0x2616a371, 0x4a41a17b, 0x7f954d5c, 0x85d62678, 0x519659ba,
+    0x22d2aa43, 0x256b7277, 0x97d8f1c0, 0xa487e15f, 0xcd4dbb25, 0xfda65b71,
+    0xe04f303a, 0xbd14e559, 0x2e99940e, 0xf8b7f805, 0x155baf43, 0x6aede65e,
+    0xcc5620c4, 0xc830c373, 0x663ede0e, 0x483f2c4f, 0x5c1ebd71, 0x542cdc5d,
+    0xfb959a0e, 0xbcab5a75, 0x5eff3956, 0xfaee8951, 0x550689db, 0x994986b6,
+    0x568710b2, 0x2e6d3f73, 0x6ef9f8b7, 0x21bf1a75, 0x5ce0304e, 0x25774ebc,
+    0x50adb6d4, 0x207d565d, 0x5862af89, 0xd2934a5c, 0x98fc1bae, 0x3f544e58,
+    0x6552d85e, 0x059bcbda, 0x4175d972, 0x34d4c875, 0x2b0ae662, 0x7e9aa971,
+    0x8d63a570, 0xe070543e, 0x5489cc62, 0x3a63bbc0, 0x82ab8ddb, 0x6557cf79,
+    0xa67a2444, 0x804cf16e, 0x225b865d, 0x8c5f56be, 0x7f1a6f57, 0xc8064f5f,
+    0xf22f347a, 0x9f212477, 0xa371fe96, 0x4686f9ad, 0x98ad4f5f, 0x899dafaf,
+    0x019acdbb, 0x235c48de, 0xb71ee044, 0xc2e76456, 0x534ba171, 0x8e0b7a7d,
+    0x856f1c79, 0x20f1ca01, 0x452ce08c, 0x028987d1, 0xc41de563, 0xd148657b,
+    0x532a412e, 0x0fe0036c, 0xe933d773, 0x99e7507d, 0x3611f170, 0x74a77076,
+    0x48d8566a, 0xb7d8fa76, 0x18fc4771, 0xe84ef27a, 0x305a8177, 0x2bfbae6f,
+    0xf5c1e854, 0xc31060b7, 0x8f06974f, 0x7b466817, 0xdd81f371, 0x9a0ca7b7,
+    0xaecfa405, 0x7715bd1b, 0x2206e42e, 0x13089b6e, 0x803bbc71, 0x5cef293b,
+    0xe46ecb45, 0xde215771, 0xa6ed3fda, 0x692d65b6, 0x85c27254, 0x6ee32e53,
+    0xd4b121b2, 0xb4004ea6, 0xba67c454, 0x42779a42, 0xe58e19bc, 0x9bb8216e,
+    0x6eb54105, 0x1184e079, 0x759610b7, 0x8918597b, 0x2b6cadb4, 0x464717c6,
+    0xf6caa8b4, 0x54e4b2de, 0xbfe9b8b2, 0x5da925b7, 0xe34699bb, 0xde171fbc,
+    0xd6643074, 0x49a6b777, 0x4ec50ec3, 0x61704cde, 0xd09ffa76, 0x897f8932,
+    0xc5ac9b6e, 0x0207d8ab, 0x9428dfb2, 0xdc7c47b7, 0x6450357b, 0x8ce677b0,
+    0xa769a75d, 0xa64a02b7, 0x03dfd85e, 0xdc60a6df, 0x98167c40, 0x1cdbe77a,
+    0xcfd0a52e, 0xf4a2f17a, 0x9c1981b6, 0xc1cb10b7, 0xa078a6dc, 0x05353705,
+    0xca1df4dc, 0x1dc982b6, 0xe4cfbd41, 0xf18f6bbc, 0x31a9d074, 0x442c5d71,
+    0xa63a4d6f, 0x6a353677, 0xddbe4205, 0x4234135f, 0xcc84aac1, 0x53a55cb7,
+    0x58791779, 0x7b77557d, 0xfef6147b, 0xea7f4abe, 0x67ef07dd, 0xef63554d,
+    0x780bf37a, 0xe93a1c75, 0x0415203b, 0x570f3e54, 0x7105b03c, 0x5bf45ec3,
+    0xa6e250b7, 0x469938da, 0x5962293b, 0xab16e47c, 0x08c0835d, 0xd37fe97a,
+    0x462b7857, 0xbb46f37a, 0x7747e55c, 0xea01da0e, 0xd115d03a, 0xbb9ab777,
+    0xeb2f6b0e, 0xea53b64d, 0xa2cf11da, 0xd2888ab6, 0xe83a624e, 0xa7208c3d,
+    0xcacbbc56, 0x92275bdf, 0xfee3c07a, 0xbc934558, 0xe5ce8777, 0x05d75971,
+    0x6edc512a, 0xc5070165, 0x26083905, 0x0ebd9f6e, 0x44a956d9, 0x7f5f930e,
+    0x6ba694af, 0x7cf29773, 0x9b545378, 0x2a36b977, 0x24202477, 0x0151014d,
+    0x18534b3d, 0x5a54047a, 0x414ab776, 0x9619345c, 0x92065e71, 0x8e4ad5ab,
+    0xa95c735d, 0xabe4a93e, 0x04644e48, 0x2372a9b4, 0x4d81a84f, 0xc5d76672,
+    0x88eaa6cb, 0xe052e774, 0x172fca78, 0x3cfe9d9f, 0xebb40b53, 0x169c557d,
+    0xab7a1f50, 0x3f21ac42, 0x51d8ec97, 0x2c51e662, 0xc43602bc, 0x91e7be71,
+    0xaf88f402, 0x5222b03c, 0x67939d4f, 0x35f09562, 0xb986e45c, 0x98752f3b,
+    0xa3b3143c, 0x6c04ff62, 0x48902db7, 0xa83659c7, 0x75378529, 0x33be5971,
+    0xf9c2304e, 0x80ee8472, 0x5fb30db7, 0xba55b2dc, 0x7af86bb6, 0x378b0b6c,
+    0x71c0fcde, 0xc8609cd5, 0x1068ed8d, 0xa3ee517a, 0x3ab213b2, 0x47c7eb7a,
+    0xd652f460, 0x696994b6, 0x79b0c373, 0x21e40d5e, 0xb4756171, 0xca4aed8d,
+    0x2ac04959, 0x21fc2e24, 0xe7bc7f3b, 0xd5f70b79, 0xa82b77d9, 0xee2219bc,
+    0xbe26d36e, 0xae43aa7c, 0x80237da3, 0xbd505224, 0xfcbde570, 0x5e35ec02,
+    0x54f564bc, 0xc1a6026a, 0x6ec0255b, 0xc7e91c41, 0x6a09314e, 0x3785f7be,
+    0x7b044565, 0x50ce51bc, 0x37c48c3d, 0x51a30fb7, 0x91ed273a, 0x8f4a5302,
+    0xe3692d05, 0xbc431274, 0xbdecc3be, 0x3d3e1dc2, 0x6754d85e, 0xb39ff42e,
+    0xc2d64bb8, 0xfe78ce73, 0xc0c5f9b7, 0x8fee5d7b, 0xe7fa715c, 0x948017b2,
+    0x2a6c8ade, 0x98dfe062, 0x657aa17b, 0xee61fc5e, 0xeb3e754a, 0x3af33f6c,
+    0x56684b5c, 0x159d50b7, 0xee389b3d, 0x3511be6d, 0xecd3147b, 0x22c6515f,
+    0xc766a23d, 0x5c731732, 0x50ff3365, 0x8eca7552, 0xe5aa40b6, 0x3effe37a,
+    0x152e9673, 0x9ff2c36e, 0x5cb1d41b, 0x255d7777, 0xb786df80, 0xbceba971,
+    0x6602acd5, 0x5738ff77, 0x0ec805d4, 0x0b340070, 0x2dda0356, 0xc394a555,
+    0x1dbf0a70, 0x1acc5361, 0xef93bf58, 0x916fd90e, 0x68303bb7, 0x667c7fce,
+    0x08c39e4e, 0xa18f5d71, 0x19b12a1f, 0xe6a42d4e, 0x291c9b0e, 0x296a366c,
+    0x62a8fe3a, 0x6f8e5ebc, 0x171c5e17, 0x9cf5cbbe, 0x9d28ce59, 0x12d572d9,
+    0xe62bc573, 0xdac86bca, 0x1434b2b4, 0x9256cb51, 0x6d476870, 0xda10e27a,
+    0x07d00477, 0xbe5f6176, 0x021f67bc, 0xc9a90cb7, 0x1006a84b, 0x7d24ce5c,
+    0x82543cbe, 0x1083b0c9, 0x3c73705e, 0x51348dd1, 0x27beba3d, 0x1373373b,
+    0xd94f51bc, 0x2f180070, 0xea36d33a, 0x901b27ab, 0xc3294fb2, 0x20764e5b,
+    0x25640353, 0x149f495c, 0x9164d550, 0x4a33767d, 0x7890d31b, 0x2bf12a4e,
+    0xe5aa69b8, 0x70731732, 0x5687fe05, 0x9a3dda47, 0x6964e87a, 0xa2368d29,
+    0xf1932845, 0xd0f0ce79, 0x5e0a5e70, 0x462b0574, 0x8f2839da, 0xa25c8753,
+    0x869f92db, 0xe47d15af, 0xe2324c71, 0x3e133501, 0x19f69e7b, 0xeedda048,
+    0xc251da0e, 0xc3565545, 0x5d94e152, 0x1ecfd43e, 0xc84543d5, 0x321c5e70,
+    0xa2b5f74d, 0x28469473, 0x9b2a5201, 0x81c6e977, 0x8c76724f, 0x05f5ec69,
+    0xce6fea7c, 0x6b7c39da, 0x09fdaa7b, 0xb006d080, 0xb22cc2dd, 0xa032fb6e,
+    0xa7173805, 0x078b1654, 0xa260e26d, 0x10d5a57c, 0xdc260774, 0xc30d993d,
+    0x7b104dde, 0x2fe4f972, 0x46e65dde, 0x8f18a07b, 0x3835bb57, 0x422c5e70,
+    0x2adf4bb8, 0xa56ad076, 0xa31fd254, 0xccdee77a, 0x932cd073, 0xf6a74476,
+    0xa7a50558, 0xb8cadfb2, 0x9be19a5e, 0x44cc487c, 0x8380187d, 0x09aae659,
+    0xd02bc136, 0x652c717d, 0x9f9dff6d, 0x618ced72, 0x047eb5dc, 0x82f0f071,
+    0x37fed7de, 0xd4c4e273, 0x8fd1048e, 0x38810c7b, 0x916691c9, 0x8c3b3492,
+    0x0736b84f, 0x0d3f8dd1, 0xb5e4d373, 0xfb02a277, 0x4d46a23c, 0x85883c01,
+    0xa2beea7a, 0xb8cda952, 0xfa6d4b5c, 0xf8a0df72, 0xa799f0df, 0xee5e45de,
+    0xb7cb70ab, 0xd99a53bc, 0x7d8e684a, 0x0ded517a, 0xbb0c5e70, 0x5aa78cdb};
 
-//YACOIN TODO update seeds
-::uint32_t pnSeed[] =
-{
-    0x555b7158, 0x8ef3dfdd, 0x276a5248, 0xcda67076, 0x36c4515f, 0x4ad54bb8, 0x913e884f, 0x3829c6c3,
-    0x78fda1d8, 0xc0d97550, 0x1cd138b7, 0xb9e18377, 0x18407076, 0x028b77b6, 0xb2e3344e, 0xc0fd6605,
-    0xa42a7d0e, 0x666e8e71, 0xbddf4bda, 0xe7d1d3d5, 0x228f02af, 0x36485e71, 0x132a1418, 0x30375665,
-    0x72c0e662, 0x31542551, 0x9ed1dd0e, 0xb285f355, 0x75815e31, 0x555b21be, 0x376b045e, 0x0f04a4cd,
-    0x7cc4a17b, 0x1b82e5c5, 0x77037b70, 0xadeb856c, 0x64e1fdb2, 0x360460d0, 0x363c03da, 0x357de072,
-    0x6519d25b, 0xd894437a, 0x33f1c851, 0x0c3c0a2e, 0x475a565d, 0xb163526e, 0xd3857247, 0x93b3fa76,
-    0x0c267977, 0xd640bccf, 0x15b057cb, 0x6f782942, 0x15e4d4de, 0x03720205, 0xbcd1048e, 0x0242d80c,
-    0xc2f25a75, 0x09e13aad, 0x5b8c587a, 0x6851995a, 0x9deaf7de, 0x93508bae, 0x71cd32c3, 0xe9eb856c,
-    0x6783223b, 0x4aba54c6, 0xe4abbfde, 0x4c4e03b7, 0x1ee0fd74, 0x2b382753, 0x63218977, 0x9ab8cd71,
-    0x2a8703b9, 0xfa75ae52, 0xcefe4771, 0x026ea2dc, 0x02754e4d, 0x6a2dd53a, 0x5dabf2de, 0x0cb08dca,
-    0x99798459, 0x1d2e597c, 0xa430203b, 0x64c34b25, 0x237ab751, 0x2616a371, 0x4a41a17b, 0x7f954d5c,
-    0x85d62678, 0x519659ba, 0x22d2aa43, 0x256b7277, 0x97d8f1c0, 0xa487e15f, 0xcd4dbb25, 0xfda65b71,
-    0xe04f303a, 0xbd14e559, 0x2e99940e, 0xf8b7f805, 0x155baf43, 0x6aede65e, 0xcc5620c4, 0xc830c373,
-    0x663ede0e, 0x483f2c4f, 0x5c1ebd71, 0x542cdc5d, 0xfb959a0e, 0xbcab5a75, 0x5eff3956, 0xfaee8951,
-    0x550689db, 0x994986b6, 0x568710b2, 0x2e6d3f73, 0x6ef9f8b7, 0x21bf1a75, 0x5ce0304e, 0x25774ebc,
-    0x50adb6d4, 0x207d565d, 0x5862af89, 0xd2934a5c, 0x98fc1bae, 0x3f544e58, 0x6552d85e, 0x059bcbda,
-    0x4175d972, 0x34d4c875, 0x2b0ae662, 0x7e9aa971, 0x8d63a570, 0xe070543e, 0x5489cc62, 0x3a63bbc0,
-    0x82ab8ddb, 0x6557cf79, 0xa67a2444, 0x804cf16e, 0x225b865d, 0x8c5f56be, 0x7f1a6f57, 0xc8064f5f,
-    0xf22f347a, 0x9f212477, 0xa371fe96, 0x4686f9ad, 0x98ad4f5f, 0x899dafaf, 0x019acdbb, 0x235c48de,
-    0xb71ee044, 0xc2e76456, 0x534ba171, 0x8e0b7a7d, 0x856f1c79, 0x20f1ca01, 0x452ce08c, 0x028987d1,
-    0xc41de563, 0xd148657b, 0x532a412e, 0x0fe0036c, 0xe933d773, 0x99e7507d, 0x3611f170, 0x74a77076,
-    0x48d8566a, 0xb7d8fa76, 0x18fc4771, 0xe84ef27a, 0x305a8177, 0x2bfbae6f, 0xf5c1e854, 0xc31060b7,
-    0x8f06974f, 0x7b466817, 0xdd81f371, 0x9a0ca7b7, 0xaecfa405, 0x7715bd1b, 0x2206e42e, 0x13089b6e,
-    0x803bbc71, 0x5cef293b, 0xe46ecb45, 0xde215771, 0xa6ed3fda, 0x692d65b6, 0x85c27254, 0x6ee32e53,
-    0xd4b121b2, 0xb4004ea6, 0xba67c454, 0x42779a42, 0xe58e19bc, 0x9bb8216e, 0x6eb54105, 0x1184e079,
-    0x759610b7, 0x8918597b, 0x2b6cadb4, 0x464717c6, 0xf6caa8b4, 0x54e4b2de, 0xbfe9b8b2, 0x5da925b7,
-    0xe34699bb, 0xde171fbc, 0xd6643074, 0x49a6b777, 0x4ec50ec3, 0x61704cde, 0xd09ffa76, 0x897f8932,
-    0xc5ac9b6e, 0x0207d8ab, 0x9428dfb2, 0xdc7c47b7, 0x6450357b, 0x8ce677b0, 0xa769a75d, 0xa64a02b7,
-    0x03dfd85e, 0xdc60a6df, 0x98167c40, 0x1cdbe77a, 0xcfd0a52e, 0xf4a2f17a, 0x9c1981b6, 0xc1cb10b7,
-    0xa078a6dc, 0x05353705, 0xca1df4dc, 0x1dc982b6, 0xe4cfbd41, 0xf18f6bbc, 0x31a9d074, 0x442c5d71,
-    0xa63a4d6f, 0x6a353677, 0xddbe4205, 0x4234135f, 0xcc84aac1, 0x53a55cb7, 0x58791779, 0x7b77557d,
-    0xfef6147b, 0xea7f4abe, 0x67ef07dd, 0xef63554d, 0x780bf37a, 0xe93a1c75, 0x0415203b, 0x570f3e54,
-    0x7105b03c, 0x5bf45ec3, 0xa6e250b7, 0x469938da, 0x5962293b, 0xab16e47c, 0x08c0835d, 0xd37fe97a,
-    0x462b7857, 0xbb46f37a, 0x7747e55c, 0xea01da0e, 0xd115d03a, 0xbb9ab777, 0xeb2f6b0e, 0xea53b64d,
-    0xa2cf11da, 0xd2888ab6, 0xe83a624e, 0xa7208c3d, 0xcacbbc56, 0x92275bdf, 0xfee3c07a, 0xbc934558,
-    0xe5ce8777, 0x05d75971, 0x6edc512a, 0xc5070165, 0x26083905, 0x0ebd9f6e, 0x44a956d9, 0x7f5f930e,
-    0x6ba694af, 0x7cf29773, 0x9b545378, 0x2a36b977, 0x24202477, 0x0151014d, 0x18534b3d, 0x5a54047a,
-    0x414ab776, 0x9619345c, 0x92065e71, 0x8e4ad5ab, 0xa95c735d, 0xabe4a93e, 0x04644e48, 0x2372a9b4,
-    0x4d81a84f, 0xc5d76672, 0x88eaa6cb, 0xe052e774, 0x172fca78, 0x3cfe9d9f, 0xebb40b53, 0x169c557d,
-    0xab7a1f50, 0x3f21ac42, 0x51d8ec97, 0x2c51e662, 0xc43602bc, 0x91e7be71, 0xaf88f402, 0x5222b03c,
-    0x67939d4f, 0x35f09562, 0xb986e45c, 0x98752f3b, 0xa3b3143c, 0x6c04ff62, 0x48902db7, 0xa83659c7,
-    0x75378529, 0x33be5971, 0xf9c2304e, 0x80ee8472, 0x5fb30db7, 0xba55b2dc, 0x7af86bb6, 0x378b0b6c,
-    0x71c0fcde, 0xc8609cd5, 0x1068ed8d, 0xa3ee517a, 0x3ab213b2, 0x47c7eb7a, 0xd652f460, 0x696994b6,
-    0x79b0c373, 0x21e40d5e, 0xb4756171, 0xca4aed8d, 0x2ac04959, 0x21fc2e24, 0xe7bc7f3b, 0xd5f70b79,
-    0xa82b77d9, 0xee2219bc, 0xbe26d36e, 0xae43aa7c, 0x80237da3, 0xbd505224, 0xfcbde570, 0x5e35ec02,
-    0x54f564bc, 0xc1a6026a, 0x6ec0255b, 0xc7e91c41, 0x6a09314e, 0x3785f7be, 0x7b044565, 0x50ce51bc,
-    0x37c48c3d, 0x51a30fb7, 0x91ed273a, 0x8f4a5302, 0xe3692d05, 0xbc431274, 0xbdecc3be, 0x3d3e1dc2,
-    0x6754d85e, 0xb39ff42e, 0xc2d64bb8, 0xfe78ce73, 0xc0c5f9b7, 0x8fee5d7b, 0xe7fa715c, 0x948017b2,
-    0x2a6c8ade, 0x98dfe062, 0x657aa17b, 0xee61fc5e, 0xeb3e754a, 0x3af33f6c, 0x56684b5c, 0x159d50b7,
-    0xee389b3d, 0x3511be6d, 0xecd3147b, 0x22c6515f, 0xc766a23d, 0x5c731732, 0x50ff3365, 0x8eca7552,
-    0xe5aa40b6, 0x3effe37a, 0x152e9673, 0x9ff2c36e, 0x5cb1d41b, 0x255d7777, 0xb786df80, 0xbceba971,
-    0x6602acd5, 0x5738ff77, 0x0ec805d4, 0x0b340070, 0x2dda0356, 0xc394a555, 0x1dbf0a70, 0x1acc5361,
-    0xef93bf58, 0x916fd90e, 0x68303bb7, 0x667c7fce, 0x08c39e4e, 0xa18f5d71, 0x19b12a1f, 0xe6a42d4e,
-    0x291c9b0e, 0x296a366c, 0x62a8fe3a, 0x6f8e5ebc, 0x171c5e17, 0x9cf5cbbe, 0x9d28ce59, 0x12d572d9,
-    0xe62bc573, 0xdac86bca, 0x1434b2b4, 0x9256cb51, 0x6d476870, 0xda10e27a, 0x07d00477, 0xbe5f6176,
-    0x021f67bc, 0xc9a90cb7, 0x1006a84b, 0x7d24ce5c, 0x82543cbe, 0x1083b0c9, 0x3c73705e, 0x51348dd1,
-    0x27beba3d, 0x1373373b, 0xd94f51bc, 0x2f180070, 0xea36d33a, 0x901b27ab, 0xc3294fb2, 0x20764e5b,
-    0x25640353, 0x149f495c, 0x9164d550, 0x4a33767d, 0x7890d31b, 0x2bf12a4e, 0xe5aa69b8, 0x70731732,
-    0x5687fe05, 0x9a3dda47, 0x6964e87a, 0xa2368d29, 0xf1932845, 0xd0f0ce79, 0x5e0a5e70, 0x462b0574,
-    0x8f2839da, 0xa25c8753, 0x869f92db, 0xe47d15af, 0xe2324c71, 0x3e133501, 0x19f69e7b, 0xeedda048,
-    0xc251da0e, 0xc3565545, 0x5d94e152, 0x1ecfd43e, 0xc84543d5, 0x321c5e70, 0xa2b5f74d, 0x28469473,
-    0x9b2a5201, 0x81c6e977, 0x8c76724f, 0x05f5ec69, 0xce6fea7c, 0x6b7c39da, 0x09fdaa7b, 0xb006d080,
-    0xb22cc2dd, 0xa032fb6e, 0xa7173805, 0x078b1654, 0xa260e26d, 0x10d5a57c, 0xdc260774, 0xc30d993d,
-    0x7b104dde, 0x2fe4f972, 0x46e65dde, 0x8f18a07b, 0x3835bb57, 0x422c5e70, 0x2adf4bb8, 0xa56ad076,
-    0xa31fd254, 0xccdee77a, 0x932cd073, 0xf6a74476, 0xa7a50558, 0xb8cadfb2, 0x9be19a5e, 0x44cc487c,
-    0x8380187d, 0x09aae659, 0xd02bc136, 0x652c717d, 0x9f9dff6d, 0x618ced72, 0x047eb5dc, 0x82f0f071,
-    0x37fed7de, 0xd4c4e273, 0x8fd1048e, 0x38810c7b, 0x916691c9, 0x8c3b3492, 0x0736b84f, 0x0d3f8dd1,
-    0xb5e4d373, 0xfb02a277, 0x4d46a23c, 0x85883c01, 0xa2beea7a, 0xb8cda952, 0xfa6d4b5c, 0xf8a0df72,
-    0xa799f0df, 0xee5e45de, 0xb7cb70ab, 0xd99a53bc, 0x7d8e684a, 0x0ded517a, 0xbb0c5e70, 0x5aa78cdb
-};
-
-//YACOIN TODO 
-const char* pchTorSeed[] = 
-{
+// YACOIN TODO
+const char *pchTorSeed[] = {
 #ifdef _MSC_VER
     ""
 #else
-   // "needtoimplement.onion",
+// "needtoimplement.onion",
 #endif
 };
 
@@ -1954,34 +1880,32 @@ static void DumpAddresses()
 {
     ::int64_t nStart = GetTimeMillis();
 
-    CAddrDB adb;    // does a GetDataDir() in ctor for "peers.dat"
+    CAddrDB adb; // does a GetDataDir() in ctor for "peers.dat"
     adb.Write(addrman);
 
     if (fDebug)
-        printf("Flushed %d addresses to peers.dat  %" PRId64 "ms\n",
-               addrman.size(),
-               GetTimeMillis() - nStart
-              );
+        printf("Flushed %d addresses to peers.dat  %" PRId64 "ms\n", addrman.size(),
+               GetTimeMillis() - nStart);
 }
 
-void ThreadDumpAddress2(void* parg)
+void ThreadDumpAddress2(void *parg)
 {
     ++vnThreadsRunning[THREAD_DUMPADDRESS];
     while (!fShutdown)
     {
-        if( fDebug )
-            (void)printf( "ThreadDumpAddress2 is looping"
-                         "\n"
-                        );
+        if (fDebug)
+            (void)printf("ThreadDumpAddress2 is looping"
+                         "\n");
         DumpAddresses();
         --vnThreadsRunning[THREAD_DUMPADDRESS];
-        Sleep(1 * nSecondsperMinute * nMillisecondsPerSecond);  // try this arbitrary value
+        Sleep(1 * nSecondsperMinute *
+              nMillisecondsPerSecond); // try this arbitrary value
         ++vnThreadsRunning[THREAD_DUMPADDRESS];
     }
     --vnThreadsRunning[THREAD_DUMPADDRESS];
 }
 
-void ThreadDumpAddress(void* parg)
+void ThreadDumpAddress(void *parg)
 {
     // Make this thread recognisable as the address dumping thread
     RenameThread("yacoin-adrdump");
@@ -1990,14 +1914,14 @@ void ThreadDumpAddress(void* parg)
     {
         ThreadDumpAddress2(parg);
     }
-    catch (std::exception& e)
+    catch (std::exception &e)
     {
         PrintException(&e, "ThreadDumpAddress()");
     }
     printf("ThreadDumpAddress exited\n");
 }
 
-void ThreadOpenConnections(void* parg)
+void ThreadOpenConnections(void *parg)
 {
     // Make this thread recognisable as the connection opening thread
     RenameThread("yacoin-opencon");
@@ -2008,7 +1932,7 @@ void ThreadOpenConnections(void* parg)
         ThreadOpenConnections2(parg);
         --vnThreadsRunning[THREAD_OPENCONNECTIONS];
     }
-    catch (std::exception& e)
+    catch (std::exception &e)
     {
         --vnThreadsRunning[THREAD_OPENCONNECTIONS];
         PrintException(&e, "ThreadOpenConnections()");
@@ -2031,10 +1955,8 @@ void static ProcessOneShot()
         strDest = vOneShots.front();
         vOneShots.pop_front();
     }
-    CAddress
-        addr;
-    CSemaphoreGrant
-        grant(*semOutbound, true);
+    CAddress addr;
+    CSemaphoreGrant grant(*semOutbound, true);
     if (grant)
     {
         if (!OpenNetworkConnection(addr, &grant, strDest.c_str(), true))
@@ -2043,17 +1965,17 @@ void static ProcessOneShot()
 }
 
 // ppcoin: stake minter thread
-void static ThreadStakeMinter(void* parg)
+void static ThreadStakeMinter(void *parg)
 {
     printf("ThreadStakeMinter started\n");
-    CWallet* pwallet = (CWallet*)parg;
+    CWallet *pwallet = (CWallet *)parg;
     try
     {
         ++vnThreadsRunning[THREAD_MINTER];
         StakeMinter(pwallet);
         --vnThreadsRunning[THREAD_MINTER];
     }
-    catch (std::exception& e)
+    catch (std::exception &e)
     {
         --vnThreadsRunning[THREAD_MINTER];
         PrintException(&e, "ThreadStakeMinter()");
@@ -2063,10 +1985,11 @@ void static ThreadStakeMinter(void* parg)
         --vnThreadsRunning[THREAD_MINTER];
         PrintException(NULL, "ThreadStakeMinter()");
     }
-    printf("ThreadStakeMinter exiting, %d threads remaining\n", vnThreadsRunning[THREAD_MINTER]);
+    printf("ThreadStakeMinter exiting, %d threads remaining\n",
+           vnThreadsRunning[THREAD_MINTER]);
 }
 
-void ThreadOpenConnections2(void* parg)
+void ThreadOpenConnections2(void *parg)
 {
     printf("ThreadOpenConnections started\n");
 
@@ -2079,15 +2002,13 @@ void ThreadOpenConnections2(void* parg)
         for (::int64_t nLoop = 0;; ++nLoop) // can overflow??
         {
             ProcessOneShot();
-            BOOST_FOREACH(string strAddr, mapMultiArgs["-connect"])
+            BOOST_FOREACH (string strAddr, mapMultiArgs["-connect"])
             {
-                CAddress
-                    addr;
-              //OpenNetworkConnection(addr, NULL, strAddr.c_str());
-                bool
-                    fConnected;
+                CAddress addr;
+                // OpenNetworkConnection(addr, NULL, strAddr.c_str());
+                bool fConnected;
                 fConnected = OpenNetworkConnection(addr, NULL, strAddr.c_str());
-                if( fConnected )
+                if (fConnected)
                 {
                     printf(" connected\n");
                 }
@@ -2097,8 +2018,8 @@ void ThreadOpenConnections2(void* parg)
                 }
                 for (int i = 0; (i < 10) && (i < nLoop); ++i)
                 {
-                  // Sleep(500);
-                    Sleep( 0 ); //Sleep(5 * nOneHundredMilliseconds);
+                    // Sleep(500);
+                    Sleep(0); // Sleep(5 * nOneHundredMilliseconds);
                     if (fShutdown)
                         return;
                 }
@@ -2108,22 +2029,21 @@ void ThreadOpenConnections2(void* parg)
 
     // Initiate network connections
     ::int64_t nStart = GetTime();
-    int
-        nLoopCounter = 0;
+    int nLoopCounter = 0;
     while (true)
     {
-        if( fDebug && fPrintToConsole )
-            if( 0== (++nLoopCounter % 100) )
-                (void)printf( ".01 ThreadOpenConnections2 is looping\n" );
+        if (fDebug && fPrintToConsole)
+            if (0 == (++nLoopCounter % 100))
+                (void)printf(".01 ThreadOpenConnections2 is looping\n");
         ProcessOneShot();
 
         ++vnThreadsRunning[THREAD_OPENCONNECTIONS];
-      //Sleep(500);                 // Is this by any chance(???) related to the above??? Or not????
-        Sleep( nOneMillisecond );
+        // Sleep(500);                 // Is this by any chance(???) related to the
+        // above??? Or not????
+        Sleep(nOneMillisecond);
         --vnThreadsRunning[THREAD_OPENCONNECTIONS];
         if (fShutdown)
             return;
-
 
         ++vnThreadsRunning[THREAD_OPENCONNECTIONS];
         CSemaphoreGrant grant(*semOutbound);
@@ -2132,12 +2052,10 @@ void ThreadOpenConnections2(void* parg)
             return;
 
         // Add seed nodes if IRC isn't working
-        if ( false && // AO: Don't add seed nodes for evaluating tests.
-            !IsLimited(NET_IPV4) &&
-            addrman.size()==0 &&
-            (GetTime() - nStart > 60) &&    // why 60? 60 what?
-            !fTestNet
-           )
+        if (false && // AO: Don't add seed nodes for evaluating tests.
+            !IsLimited(NET_IPV4) && addrman.size() == 0 &&
+            (GetTime() - nStart > 60) && // why 60? 60 what?
+            !fTestNet)
         {
             std::vector<CAddress> vAdd;
             for (unsigned int i = 0; i < ARRAYLEN(pnSeed); ++i)
@@ -2146,17 +2064,16 @@ void ThreadOpenConnections2(void* parg)
                 // it'll get a pile of addresses with newer timestamps.
                 // Seed nodes are given a random 'last seen time' of between one and two
                 // weeks ago.
-                const 
-                    ::int64_t nOneWeek = 7*24*60*60;    // in seconds I presume?????????????????????
+                const ::int64_t nOneWeek =
+                    7 * 24 * 60 * 60; // in seconds I presume?????????????????????
 
-                struct in_addr
-                    ip;
+                struct in_addr ip;
 
                 memcpy(&ip, &pnSeed[i], sizeof(ip));
 
                 CAddress addr(CService(ip, GetDefaultPort()));
 
-                addr.nTime = GetTime()-GetRand(nOneWeek)-nOneWeek;
+                addr.nTime = GetTime() - GetRand(nOneWeek) - nOneWeek;
                 vAdd.push_back(addr);
             }
             addrman.Add(vAdd, CNetAddr("127.0.0.1"));
@@ -2165,16 +2082,15 @@ void ThreadOpenConnections2(void* parg)
         // Add Tor nodes if we have connection with onion router
         if (mapArgs.count("-tor"))
         {
-            size_t
-                Length = ARRAYLEN(pchTorSeed);
+            size_t Length = ARRAYLEN(pchTorSeed);
 
             std::vector<CAddress> vAdd;
-         // for (unsigned int i = 0; i < ARRAYLEN(pchTorSeed); ++i)
+            // for (unsigned int i = 0; i < ARRAYLEN(pchTorSeed); ++i)
             for (unsigned int i = 0; i < Length; ++i)
             {
-                const ::int64_t nOneWeek = 7*24*60*60;
+                const ::int64_t nOneWeek = 7 * 24 * 60 * 60;
                 CAddress addr(CService(pchTorSeed[i], GetDefaultPort()));
-                addr.nTime = GetTime()-GetRand(nOneWeek)-nOneWeek;
+                addr.nTime = GetTime() - GetRand(nOneWeek) - nOneWeek;
                 vAdd.push_back(addr);
             }
             addrman.Add(vAdd, CNetAddr("dummyaddress.onion"));
@@ -2186,14 +2102,14 @@ void ThreadOpenConnections2(void* parg)
         CAddress addrConnect;
 
         // Only connect out to one peer per network group (/16 for IPv4).
-        // Do this here so we don't have to critsect vNodes inside mapAddresses critsect.
-        int
-            nOutbound = 0;
+        // Do this here so we don't have to critsect vNodes inside mapAddresses
+        // critsect.
+        int nOutbound = 0;
 
         set<vector<unsigned char> > setConnected;
         {
             LOCK(cs_vNodes);
-            BOOST_FOREACH(CNode* pnode, vNodes)
+            BOOST_FOREACH (CNode *pnode, vNodes)
             {
                 if (!pnode->fInbound)
                 {
@@ -2203,27 +2119,25 @@ void ThreadOpenConnections2(void* parg)
             }
         }
 
-        ::int64_t 
-            nANow = GetAdjustedTime();
+        ::int64_t nANow = GetAdjustedTime();
 
-        int
-            nTries = 0;
+        int nTries = 0;
 
         while (true)
         {
-            // use an nUnkBias between 10 (no outgoing connections) and 90 (8 outgoing connections)
-            // meaning what exactly?????????????????????????????????????????????????
+            // use an nUnkBias between 10 (no outgoing connections) and 90 (8 outgoing
+            // connections) meaning what
+            // exactly?????????????????????????????????????????????????
 
-            CAddress addr = addrman.Select(10 + min(nOutbound,8)*10);   // meaning what?????
+            CAddress addr =
+                addrman.Select(10 + min(nOutbound, 8) * 10); // meaning what?????
 
             // if we selected an invalid address, restart
-            // restart what exactly, by breaking here?????????????????????????????????????????
+            // restart what exactly, by breaking
+            // here?????????????????????????????????????????
 
-            if (
-                !addr.IsValid() || 
-                setConnected.count(addr.GetGroup()) || 
-                IsLocal(addr)
-               )
+            if (!addr.IsValid() || setConnected.count(addr.GetGroup()) ||
+                IsLocal(addr))
                 break;
 
             // If we didn't find an appropriate destination after trying
@@ -2232,31 +2146,25 @@ void ThreadOpenConnections2(void* parg)
             // seed nodes, recalculates already-connected network ranges,
             // ...) before trying new addrman addresses.
             ++nTries;
-            Sleep( nOneHundredMilliseconds );   //<<<<<<<<<<< test
+            Sleep(nOneHundredMilliseconds); //<<<<<<<<<<< test
             if (nTries > 100)
-                break;  // can this leave addrConnect uninitialized??????
+                break; // can this leave addrConnect uninitialized??????
 
             if (IsLimited(addr))
                 continue;
 
             // only consider very recently tried nodes after 30 failed attempts
-            // define very recently????????????? 
+            // define very recently?????????????
             // what is the magic # 600????????????????????????
             // Is it ten minutes?????????????????????????
             // If so, why?????????????????????????????????
 
-            if (
-                nANow - addr.nLastTry < 600 &&
-                nTries < 30
-               )
+            if (nANow - addr.nLastTry < 600 && nTries < 30)
                 continue;
 
-            // do not allow non-default ports, unless after 50 invalid addresses selected already
-            // Better English, please?????????????????????????
-            if (
-                addr.GetPort() != GetDefaultPort() && 
-                nTries < 50
-               )
+            // do not allow non-default ports, unless after 50 invalid addresses
+            // selected already Better English, please?????????????????????????
+            if (addr.GetPort() != GetDefaultPort() && nTries < 50)
                 continue;
 
             addrConnect = addr;
@@ -2264,16 +2172,15 @@ void ThreadOpenConnections2(void* parg)
         }
         if (addrConnect.IsValid())
         {
-            bool
-                fConnected;
-          //OpenNetworkConnection(addrConnect, &grant);
+            bool fConnected;
+            // OpenNetworkConnection(addrConnect, &grant);
             fConnected = OpenNetworkConnection(addrConnect, &grant);
         }
-        Sleep( 5 * nOneHundredMilliseconds );   //<<<<<<<<<<< test 1/2 second
+        Sleep(5 * nOneHundredMilliseconds); //<<<<<<<<<<< test 1/2 second
     }
 }
 
-void ThreadOpenAddedConnections(void* parg)
+void ThreadOpenAddedConnections(void *parg)
 {
     // Make this thread recognisable as the connection opening thread
     RenameThread("yacoin-open added connections started");
@@ -2284,12 +2191,12 @@ void ThreadOpenAddedConnections(void* parg)
         ThreadOpenAddedConnections2(parg);
         --vnThreadsRunning[THREAD_ADDEDCONNECTIONS];
     }
-    catch (std::exception& e) 
+    catch (std::exception &e)
     {
         --vnThreadsRunning[THREAD_ADDEDCONNECTIONS];
         PrintException(&e, "ThreadOpenAddedConnections()");
-    } 
-    catch (...) 
+    }
+    catch (...)
     {
         --vnThreadsRunning[THREAD_ADDEDCONNECTIONS];
         PrintException(NULL, "ThreadOpenAddedConnections()");
@@ -2297,7 +2204,7 @@ void ThreadOpenAddedConnections(void* parg)
     printf("ThreadOpenAddedConnections exited\n");
 }
 
-void ThreadOpenAddedConnections2(void* parg)
+void ThreadOpenAddedConnections2(void *parg)
 {
     printf("ThreadOpenAddedConnections2 started\n");
 
@@ -2306,80 +2213,79 @@ void ThreadOpenAddedConnections2(void* parg)
         vAddedNodes = mapMultiArgs["-addnode"];
     }
 
-    if (HaveNameProxy()) 
+    if (HaveNameProxy())
     {
-        while(!fShutdown) 
+        while (!fShutdown)
         {
             list<string> lAddresses(0);
             {
                 LOCK(cs_vAddedNodes);
-                BOOST_FOREACH(string& strAddNode, vAddedNodes)
+                BOOST_FOREACH (string &strAddNode, vAddedNodes)
                     lAddresses.push_back(strAddNode);
             }
-            BOOST_FOREACH(string& strAddNode, lAddresses) 
+            BOOST_FOREACH (string &strAddNode, lAddresses)
             {
                 CAddress addr;
                 CSemaphoreGrant grant(*semOutbound);
-                bool
-                    fConnected;
+                bool fConnected;
                 fConnected = OpenNetworkConnection(addr, &grant, strAddNode.c_str());
-              //Sleep(500);     // again, what, why, etc....?
+                // Sleep(500);     // again, what, why, etc....?
                 Sleep(5 * nOneHundredMilliseconds);
             }
             --vnThreadsRunning[THREAD_ADDEDCONNECTIONS];
-          //Sleep(120000); // Retry every 2 minutes
-                            // why??? Is this related to any other magic #?????????????????????????
+            // Sleep(120000); // Retry every 2 minutes
+            // why??? Is this related to any other magic #?????????????????????????
             Sleep(2 * nSecondsperMinute * nMillisecondsPerSecond);
             ++vnThreadsRunning[THREAD_ADDEDCONNECTIONS];
         }
         return;
     }
 
-    for (::uint32_t i = 0; true; ++i)   // for ever
+    for (::uint32_t i = 0; true; ++i) // for ever
     {
-        if( fDebug && fPrintToConsole )
-            (void)printf( "ThreadOpenAddedConnections2 is looping\n" );
+        if (fDebug && fPrintToConsole)
+            (void)printf("ThreadOpenAddedConnections2 is looping\n");
         list<string> lAddresses(0);
         {
             LOCK(cs_vAddedNodes);
-            BOOST_FOREACH(string& strAddNode, vAddedNodes)
+            BOOST_FOREACH (string &strAddNode, vAddedNodes)
                 lAddresses.push_back(strAddNode);
         }
 
         list<vector<CService> > lservAddressesToAdd(0);
-        BOOST_FOREACH(string& strAddNode, lAddresses)
+        BOOST_FOREACH (string &strAddNode, lAddresses)
         {
             vector<CService> vservNode(0);
-            if (Lookup(strAddNode.c_str(), vservNode, GetDefaultPort(), fNameLookup, 0))
+            if (Lookup(strAddNode.c_str(), vservNode, GetDefaultPort(), fNameLookup,
+                       0))
             {
                 lservAddressesToAdd.push_back(vservNode);
                 {
                     LOCK(cs_setservAddNodeAddresses);
-                    BOOST_FOREACH(CService& serv, vservNode)
+                    BOOST_FOREACH (CService &serv, vservNode)
                         setservAddNodeAddresses.insert(serv);
                 }
             }
         }
-        // Attempt to connect to each IP for each addnode entry until at least one 
-        // is successful per addnode entry (keeping in mind that addnode entries 
+        // Attempt to connect to each IP for each addnode entry until at least one
+        // is successful per addnode entry (keeping in mind that addnode entries
         // can have many IPs if fNameLookup)
         {
             LOCK(cs_vNodes);
-            BOOST_FOREACH(CNode* pnode, vNodes)
+            BOOST_FOREACH (CNode *pnode, vNodes)
             {
-                for (list<vector<CService> >::iterator it = lservAddressesToAdd.begin(); 
-                     it != lservAddressesToAdd.end(); 
-                     //it++
-                     ++it
-                    )
+                for (list<vector<CService> >::iterator it = lservAddressesToAdd.begin();
+                     it != lservAddressesToAdd.end();
+                     // it++
+                     ++it)
                 {
-                    BOOST_FOREACH(CService& addrNode, *(it))
+                    BOOST_FOREACH (CService &addrNode, *(it))
                     {
 #ifndef _MSC_VER
                         if (pnode->addr == addrNode)
                         {
                             it = lservAddressesToAdd.erase(it);
-                            if(it != lservAddressesToAdd.begin())
+                            if (it != lservAddressesToAdd.begin())
                                 it--;
                             break;
                         }
@@ -2389,37 +2295,38 @@ void ThreadOpenAddedConnections2(void* parg)
                         {
                             it = lservAddressesToAdd.erase(it);
                             // now it gets tricky!
-                            if( lservAddressesToAdd.empty() )
-                                break;          // can't --it, nor ++it
+                            if (lservAddressesToAdd.empty())
+                                break; // can't --it, nor ++it
                             // else it's not empty, so
                             if (it == lservAddressesToAdd.begin())
-                                break;          // can't --it
-                            --it;               // finally, a legal place!!    
+                                break; // can't --it
+                            --it;      // finally, a legal place!!
                             break;
                         }
                         // else we stay in the inner BOOST_FOREACH() loop
                     }
-                    if( lservAddressesToAdd.empty() )
-                        break;      // can't do a ++it
+                    if (lservAddressesToAdd.empty())
+                        break; // can't do a ++it
 #endif
                     if (it == lservAddressesToAdd.end())
                         break;
                 }
             }
         }
-        BOOST_FOREACH(vector<CService>& vserv, lservAddressesToAdd)
+        BOOST_FOREACH (vector<CService> &vserv, lservAddressesToAdd)
         {
             if (vserv.size() == 0)
                 continue;
             CSemaphoreGrant grant(*semOutbound);
-            bool
-                fConnected;
+            bool fConnected;
 
-            fConnected = OpenNetworkConnection(CAddress(vserv[i % vserv.size()]), &grant);
+            fConnected =
+                OpenNetworkConnection(CAddress(vserv[i % vserv.size()]), &grant);
             if (!fShutdown)
             {
-              //Sleep(6 * nMillisecondsPerSecond);  // is this related to nConnectTimeout?
-                Sleep( nConnectTimeout );  // just trying to get rid of these magic #s
+                // Sleep(6 * nMillisecondsPerSecond);  // is this related to
+                // nConnectTimeout?
+                Sleep(nConnectTimeout); // just trying to get rid of these magic #s
             }
             else
             {
@@ -2431,11 +2338,11 @@ void ThreadOpenAddedConnections2(void* parg)
         else
         {
             --vnThreadsRunning[THREAD_ADDEDCONNECTIONS];
-            if ( !fShutdown)
+            if (!fShutdown)
             {
-                //Sleep(120000); // Retry every 2 minutes
-                //Sleep(30 * nMillisecondsPerSecond); // let's try every 30 seconds
-                Sleep( 2* nSecondsperMinute * nMillisecondsPerSecond);
+                // Sleep(120000); // Retry every 2 minutes
+                // Sleep(30 * nMillisecondsPerSecond); // let's try every 30 seconds
+                Sleep(2 * nSecondsperMinute * nMillisecondsPerSecond);
             }
             ++vnThreadsRunning[THREAD_ADDEDCONNECTIONS];
         }
@@ -2447,12 +2354,9 @@ void ThreadOpenAddedConnections2(void* parg)
 }
 
 // if successful, this moves the passed grant to the constructed node
-bool OpenNetworkConnection(
-                           const CAddress& addrConnect, 
-                           CSemaphoreGrant *grantOutbound, 
-                           const char *strDest, 
-                           bool fOneShot
-                          )
+bool OpenNetworkConnection(const CAddress &addrConnect,
+                           CSemaphoreGrant *grantOutbound, const char *strDest,
+                           bool fOneShot)
 {
     //
     // Initiate outbound network connection
@@ -2461,11 +2365,9 @@ bool OpenNetworkConnection(
         return false;
     if (!strDest)
     {
-        if (IsLocal(addrConnect) ||
-            FindNode((CNetAddr)addrConnect) || 
+        if (IsLocal(addrConnect) || FindNode((CNetAddr)addrConnect) ||
             CNode::IsBanned(addrConnect) ||
-            FindNode(addrConnect.ToStringIPPort().c_str())
-           )
+            FindNode(addrConnect.ToStringIPPort().c_str()))
             return false;
     }
     if (strDest && FindNode(strDest))
@@ -2473,8 +2375,7 @@ bool OpenNetworkConnection(
 
     --vnThreadsRunning[THREAD_OPENCONNECTIONS];
 
-    CNode
-        * pnode = ConnectNode(addrConnect, strDest);
+    CNode *pnode = ConnectNode(addrConnect, strDest);
 
     ++vnThreadsRunning[THREAD_OPENCONNECTIONS];
 
@@ -2492,57 +2393,7 @@ bool OpenNetworkConnection(
     return true;
 }
 
-// for now, use a very simple selection metric: the node from which we received
-// most recently
-double static NodeSyncScore(const CNode *pnode) 
-{
-    return -pnode->nLastRecv;
-}
-
-void static StartSync(const vector<CNode*> &vNodes) 
-{
-    CNode *pnodeNewSync = NULL;
-    double dBestScore = 0;
-
-    {
-        LOCK(cs_vNodes);
-        // Iterate over all nodes
-        BOOST_FOREACH(CNode* pnode, vNodes) 
-        {
-            // check preconditions for allowing a sync
-            if (!pnode->fClient && 
-                !pnode->fOneShot &&
-                !pnode->fDisconnect && 
-                pnode->fSuccessfullyConnected &&
-              //(pnode->nStartingHeight > (nBestHeight - 144)) &&   // within one day if BTC !!!???
-                (pnode->nStartingHeight > (nBestHeight - (int)nOnedayOfAverageBlocks)) &&   // perhaps
-                (
-                 (pnode->nVersion < NOBLKS_VERSION_START) || // why <60002 || >= 60005
-                 (pnode->nVersion >= NOBLKS_VERSION_END)    // why are 60002, 3, 4 taboo?
-                )
-               ) 
-            {   // if ok, compare node's score with the best so far
-                double dScore = NodeSyncScore(pnode);
-                if (
-                    pnodeNewSync == NULL || 
-                    (dScore > dBestScore) 
-                   )
-                {
-                    pnodeNewSync = pnode;
-                    dBestScore = dScore;
-                }
-            }
-        }
-        // if a new sync candidate was found, start sync!
-        if (pnodeNewSync) 
-        {
-            pnodeNewSync->fStartSync = true;
-            pnodeSync = pnodeNewSync;
-        }
-    }
-}
-
-void ThreadMessageHandler(void* parg)
+void ThreadMessageHandler(void *parg)
 {
     // Make this thread recognisable as the message handling thread
     RenameThread("yacoin-msghand");
@@ -2553,11 +2404,12 @@ void ThreadMessageHandler(void* parg)
         ThreadMessageHandler2(parg);
         --vnThreadsRunning[THREAD_MESSAGEHANDLER];
     }
-    catch (std::exception& e) 
+    catch (std::exception &e)
     {
         --vnThreadsRunning[THREAD_MESSAGEHANDLER];
         PrintException(&e, "ThreadMessageHandler()");
-    } catch (...) 
+    }
+    catch (...)
     {
         --vnThreadsRunning[THREAD_MESSAGEHANDLER];
         PrintException(NULL, "ThreadMessageHandler()");
@@ -2565,54 +2417,50 @@ void ThreadMessageHandler(void* parg)
     printf("ThreadMessageHandler exited\n");
 }
 
-void ThreadMessageHandler2(void* parg)
+void ThreadMessageHandler2(void *parg)
 {
     printf("ThreadMessageHandler2 started\n");
     SetThreadPriority(THREAD_PRIORITY_BELOW_NORMAL);
     int nLoopCounter = 0;
     while (!fShutdown)
-    {        
-        if( fDebug && nLoopCounter%100 == 0) {
+    {
+        if (fDebug && nLoopCounter % 100 == 0)
+        {
             printf("ThreadMessageHandler2 is looping\n");
         }
         nLoopCounter++;
-        bool fHaveSyncNode = false;
-        vector<CNode*> vNodesCopy;
+        vector<CNode *> vNodesCopy;
         {
             LOCK(cs_vNodes);
             vNodesCopy = vNodes;
-            BOOST_FOREACH(CNode* pnode, vNodesCopy) 
+            BOOST_FOREACH (CNode *pnode, vNodesCopy)
             {
                 pnode->AddRef();
-                if (pnode == pnodeSync)
-                    fHaveSyncNode = true;
             }
         }
-/*******************
-        if (!fHaveSyncNode)
-            StartSync(vNodesCopy);
-*******************/
+
         // Poll the connected nodes for messages
-        CNode* pnodeTrickle = NULL;
+        CNode *pnodeTrickle = NULL;
 
         if (!vNodesCopy.empty())
             pnodeTrickle = vNodesCopy[GetRand(vNodesCopy.size())];
 
-        BOOST_FOREACH(CNode* pnode, vNodesCopy)
-        {   // Receive messages
+        BOOST_FOREACH (CNode *pnode, vNodesCopy)
+        {
+            if (pnode->fDisconnect)
+                continue;
+            // Receive messages
             {
                 TRY_LOCK(pnode->cs_vRecv, lockRecv);
                 if (lockRecv)
-                    ProcessMessages(pnode);
+                    g_signals.ProcessMessages(pnode);
             }
             if (fShutdown)
             {
-                if( fDebug )
+                if (fDebug)
                 {
-                    (void)printf(
-                                 "ThreadMessageHandler2 is exiting(at 1)"
-                                 "\n"
-                                );
+                    (void)printf("ThreadMessageHandler2 is exiting(at 1)"
+                                 "\n");
                 }
                 return;
             }
@@ -2620,16 +2468,14 @@ void ThreadMessageHandler2(void* parg)
             {
                 TRY_LOCK(pnode->cs_vSend, lockSend);
                 if (lockSend)
-                    SendMessages(pnode, pnode == pnodeTrickle);
+                    g_signals.SendMessages(pnode, pnode == pnodeTrickle);
             }
             if (fShutdown)
             {
-                if( fDebug )
+                if (fDebug)
                 {
-                    (void)printf(
-                                 "ThreadMessageHandler2 is exiting(at 2)"
-                                 "\n"
-                                );
+                    (void)printf("ThreadMessageHandler2 is exiting(at 2)"
+                                 "\n");
                 }
                 return;
             }
@@ -2637,7 +2483,7 @@ void ThreadMessageHandler2(void* parg)
 
         {
             LOCK(cs_vNodes);
-            BOOST_FOREACH(CNode* pnode, vNodesCopy)
+            BOOST_FOREACH (CNode *pnode, vNodesCopy)
                 pnode->Release();
         }
 
@@ -2647,171 +2493,167 @@ void ThreadMessageHandler2(void* parg)
         --vnThreadsRunning[THREAD_MESSAGEHANDLER];
         if (fRequestShutdown)
             StartShutdown();
-        //Sleep( nOneHundredMilliseconds );         // again, ????
+        // Sleep( nOneHundredMilliseconds );         // again, ????
         ++vnThreadsRunning[THREAD_MESSAGEHANDLER];
         if (fShutdown)
         {
-            if( fDebug )
+            if (fDebug)
             {
-                (void)printf(
-                             "ThreadMessageHandler2 is exiting(at 3)"
-                             "\n"
-                            );
+                (void)printf("ThreadMessageHandler2 is exiting(at 3)"
+                             "\n");
             }
             return;
         }
-        Sleep( nMillisecondsPerSecond );
+        Sleep(nMillisecondsPerSecond);
     }
-    if( fDebug )
+    if (fDebug)
     {
-        (void)printf(
-                     "ThreadMessageHandler2 is exiting"
-                     "\n"
-                    );
+        (void)printf("ThreadMessageHandler2 is exiting"
+                     "\n");
     }
 }
 
-
-bool BindListenPort(const CService &addrBind, string& strError)
+bool BindListenPort(const CService &addrBind, string &strError)
 {
-//    LOCK(cs_net);
+    //    LOCK(cs_net);
     {
-    strError = "";
-    u_long
-        nOne = 1;
+        strError = "";
+        u_long nOne = 1;
 
 #ifdef WIN32
-    // Initialize Windows Sockets
-    WSADATA 
+        // Initialize Windows Sockets
+        WSADATA
         wsadata;
 
-    int 
-        ret = WSAStartup(MAKEWORD(2,2), &wsadata);
+        int ret = WSAStartup(MAKEWORD(2, 2), &wsadata);
 
-    if (ret != NO_ERROR)
-    {
-        strError = strprintf(
-                            "Error: TCP/IP socket library failed to start (WSAStartup returned error %d)",
-                            ret
-                            );
-        printf("%s\n", strError.c_str());
-        return false;
-    }
+        if (ret != NO_ERROR)
+        {
+            strError = strprintf("Error: TCP/IP socket library failed to start "
+                                 "(WSAStartup returned error %d)",
+                                 ret);
+            printf("%s\n", strError.c_str());
+            return false;
+        }
 #endif
 
-    // Create socket for listening for incoming connections
+        // Create socket for listening for incoming connections
 #ifdef USE_IPV6
-    struct sockaddr_storage sockaddr;
+        struct sockaddr_storage sockaddr;
 #else
-    struct sockaddr sockaddr;
+        struct sockaddr sockaddr;
 #endif
-    socklen_t len = sizeof(sockaddr);
-    if (!addrBind.GetSockAddr((struct sockaddr*)&sockaddr, &len))
-    {
-        strError = strprintf("Error: bind address family for %s not supported", 
-                            addrBind.ToString().c_str()
-                            );
-        printf("%s\n", strError.c_str());
-        return false;
-    }
+        socklen_t len = sizeof(sockaddr);
+        if (!addrBind.GetSockAddr((struct sockaddr *)&sockaddr, &len))
+        {
+            strError = strprintf("Error: bind address family for %s not supported",
+                                 addrBind.ToString().c_str());
+            printf("%s\n", strError.c_str());
+            return false;
+        }
 
-    SOCKET hListenSocket = socket(((struct sockaddr*)&sockaddr)->sa_family, SOCK_STREAM, IPPROTO_TCP);
-    if (hListenSocket == INVALID_SOCKET)
-    {
-        strError = strprintf("Error: Couldn't open socket for incoming connections (socket returned error %d)", 
-                             WSAGetLastError()
-                            );
-        printf("%s\n", strError.c_str());
-        clearLocalSocketError( hListenSocket );
-        return false;
-    }
+        SOCKET hListenSocket = socket(((struct sockaddr *)&sockaddr)->sa_family,
+                                      SOCK_STREAM, IPPROTO_TCP);
+        if (hListenSocket == INVALID_SOCKET)
+        {
+            strError = strprintf("Error: Couldn't open socket for incoming "
+                                 "connections (socket returned error %d)",
+                                 WSAGetLastError());
+            printf("%s\n", strError.c_str());
+            clearLocalSocketError(hListenSocket);
+            return false;
+        }
 
 #ifdef SO_NOSIGPIPE
-    // Different way of disabling SIGPIPE on BSD
-    setsockopt(hListenSocket, SOL_SOCKET, SO_NOSIGPIPE, (void*)&nOne, sizeof(int));
+        // Different way of disabling SIGPIPE on BSD
+        setsockopt(hListenSocket, SOL_SOCKET, SO_NOSIGPIPE, (void *)&nOne,
+                   sizeof(int));
 #endif
 
 #ifndef WIN32
-    // Allow binding if the port is still in TIME_WAIT state after
-    // the program was closed and restarted.  Not an issue on windows.
-    setsockopt(hListenSocket, SOL_SOCKET, SO_REUSEADDR, (void*)&nOne, sizeof(int));
+        // Allow binding if the port is still in TIME_WAIT state after
+        // the program was closed and restarted.  Not an issue on windows.
+        setsockopt(hListenSocket, SOL_SOCKET, SO_REUSEADDR, (void *)&nOne,
+                   sizeof(int));
 #endif
-
 
 #ifdef WIN32
-    // Set to non-blocking, incoming connections will also inherit this
-    if (ioctlsocket(hListenSocket, FIONBIO, &nOne) == SOCKET_ERROR)
+        // Set to non-blocking, incoming connections will also inherit this
+        if (ioctlsocket(hListenSocket, FIONBIO, &nOne) == SOCKET_ERROR)
 #else
-    if (fcntl(hListenSocket, F_SETFL, O_NONBLOCK) == SOCKET_ERROR)
+        if (fcntl(hListenSocket, F_SETFL, O_NONBLOCK) == SOCKET_ERROR)
 #endif
-    {
-        strError = strprintf("Error: Couldn't set properties on socket for incoming connections (error %d)", 
-                            WSAGetLastError()
-                            );
-        printf("%s\n", strError.c_str());
-        clearLocalSocketError( hListenSocket );
-        return false;
-    }
+        {
+            strError = strprintf("Error: Couldn't set properties on socket for "
+                                 "incoming connections (error %d)",
+                                 WSAGetLastError());
+            printf("%s\n", strError.c_str());
+            clearLocalSocketError(hListenSocket);
+            return false;
+        }
 
 #ifdef USE_IPV6
-    // some systems don't have IPV6_V6ONLY but are always v6only; others do have the option
-    // and enable it by default or not. Try to enable it, if possible.
-    if (addrBind.IsIPv6()) 
-    {
+        // some systems don't have IPV6_V6ONLY but are always v6only; others do have
+        // the option and enable it by default or not. Try to enable it, if
+        // possible.
+        if (addrBind.IsIPv6())
+        {
 #ifdef IPV6_V6ONLY
 #ifdef WIN32
-        setsockopt(hListenSocket, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)&nOne, sizeof(int));
+            setsockopt(hListenSocket, IPPROTO_IPV6, IPV6_V6ONLY, (const char *)&nOne,
+                       sizeof(int));
 #else
-        setsockopt(hListenSocket, IPPROTO_IPV6, IPV6_V6ONLY, (void*)&nOne, sizeof(int));
+            setsockopt(hListenSocket, IPPROTO_IPV6, IPV6_V6ONLY, (void *)&nOne,
+                       sizeof(int));
 #endif
 #endif
 #ifdef WIN32
-        int nProtLevel = 10 /* PROTECTION_LEVEL_UNRESTRICTED */;
-        int nParameterId = 23 /* IPV6_PROTECTION_LEVEl */;
-        // this call is allowed to fail
-        setsockopt(hListenSocket, IPPROTO_IPV6, nParameterId, (const char*)&nProtLevel, sizeof(int));
+            int nProtLevel = 10 /* PROTECTION_LEVEL_UNRESTRICTED */;
+            int nParameterId = 23 /* IPV6_PROTECTION_LEVEl */;
+            // this call is allowed to fail
+            setsockopt(hListenSocket, IPPROTO_IPV6, nParameterId,
+                       (const char *)&nProtLevel, sizeof(int));
 #endif
-    }
+        }
 #endif
 
-    if (::bind(hListenSocket, (struct sockaddr*)&sockaddr, len) == SOCKET_ERROR)
-    {
-        int nErr = WSAGetLastError();
-        if (nErr == WSAEADDRINUSE)
-            strError = strprintf(
-                                _("Unable to bind to %s on this computer. Yacoin is probably already running."), 
-                                addrBind.ToString().c_str()
-                                );
-        else
-            strError = strprintf(
-                                _("Unable to bind to %s on this computer (bind returned error %d, %s)"), 
-                                addrBind.ToString().c_str(), nErr, strerror(nErr)
-                                );
-        printf("%s\n", strError.c_str());
-        clearLocalSocketError( hListenSocket );
-        return false;
-    }
-    printf("Bound to %s\n", addrBind.ToString().c_str());
+        if (::bind(hListenSocket, (struct sockaddr *)&sockaddr, len) ==
+            SOCKET_ERROR)
+        {
+            int nErr = WSAGetLastError();
+            if (nErr == WSAEADDRINUSE)
+                strError = strprintf(_("Unable to bind to %s on this computer. Yacoin "
+                                       "is probably already running."),
+                                     addrBind.ToString().c_str());
+            else
+                strError = strprintf(_("Unable to bind to %s on this computer (bind "
+                                       "returned error %d, %s)"),
+                                     addrBind.ToString().c_str(), nErr, strerror(nErr));
+            printf("%s\n", strError.c_str());
+            clearLocalSocketError(hListenSocket);
+            return false;
+        }
+        printf("Bound to %s\n", addrBind.ToString().c_str());
 
-    // Listen for incoming connections
-    if (listen(hListenSocket, SOMAXCONN) == SOCKET_ERROR)
-    {
-        strError = strprintf(
-                            "Error: Listening for incoming connections failed (listen returned error %d)", 
-                            WSAGetLastError()
-                            );
-        printf("%s\n", strError.c_str());
-        clearLocalSocketError( hListenSocket );
-        return false;
-    }
+        // Listen for incoming connections
+        if (listen(hListenSocket, SOMAXCONN) == SOCKET_ERROR)
+        {
+            strError = strprintf("Error: Listening for incoming connections failed "
+                                 "(listen returned error %d)",
+                                 WSAGetLastError());
+            printf("%s\n", strError.c_str());
+            clearLocalSocketError(hListenSocket);
+            return false;
+        }
 
-    vhListenSocket.push_back(hListenSocket);
+        vhListenSocket.push_back(hListenSocket);
 
-    if (addrBind.IsRoutable() && fDiscover)
-        AddLocal(addrBind, LOCAL_BIND);
+        if (addrBind.IsRoutable() && fDiscover)
+            AddLocal(addrBind, LOCAL_BIND);
 
-    printf( "Socket %s initialized and listening\n",  addrBind.ToString().c_str() );
-    return true;
+        printf("Socket %s initialized and listening\n",
+               addrBind.ToString().c_str());
+        return true;
     }
 }
 
@@ -2836,18 +2678,22 @@ static void Discover()
     }
 #else
     // Get local host ip
-    struct ifaddrs* myaddrs;
+    struct ifaddrs *myaddrs;
     if (getifaddrs(&myaddrs) == 0)
     {
-        for (struct ifaddrs* ifa = myaddrs; ifa != NULL; ifa = ifa->ifa_next)
+        for (struct ifaddrs *ifa = myaddrs; ifa != NULL; ifa = ifa->ifa_next)
         {
-            if (ifa->ifa_addr == NULL) continue;
-            if ((ifa->ifa_flags & IFF_UP) == 0) continue;
-            if (strcmp(ifa->ifa_name, "lo") == 0) continue;
-            if (strcmp(ifa->ifa_name, "lo0") == 0) continue;
+            if (ifa->ifa_addr == NULL)
+                continue;
+            if ((ifa->ifa_flags & IFF_UP) == 0)
+                continue;
+            if (strcmp(ifa->ifa_name, "lo") == 0)
+                continue;
+            if (strcmp(ifa->ifa_name, "lo0") == 0)
+                continue;
             if (ifa->ifa_addr->sa_family == AF_INET)
             {
-                struct sockaddr_in* s4 = (struct sockaddr_in*)(ifa->ifa_addr);
+                struct sockaddr_in *s4 = (struct sockaddr_in *)(ifa->ifa_addr);
                 CNetAddr addr(s4->sin_addr);
                 if (AddLocal(addr, LOCAL_IF))
                     printf("IPv4 %s: %s\n", ifa->ifa_name, addr.ToString().c_str());
@@ -2855,7 +2701,7 @@ static void Discover()
 #ifdef USE_IPV6
             else if (ifa->ifa_addr->sa_family == AF_INET6)
             {
-                struct sockaddr_in6* s6 = (struct sockaddr_in6*)(ifa->ifa_addr);
+                struct sockaddr_in6 *s6 = (struct sockaddr_in6 *)(ifa->ifa_addr);
                 CNetAddr addr(s6->sin6_addr);
                 if (AddLocal(addr, LOCAL_IF))
                     printf("IPv6 %s: %s\n", ifa->ifa_name, addr.ToString().c_str());
@@ -2871,32 +2717,32 @@ static void Discover()
         NewThread(ThreadGetMyExternalIP, NULL);
 }
 
-void StartNode(void* parg)
+void StartNode(void *parg)
 {
     // Make this thread recognisable as the startup thread
     RenameThread("yacoin-start");
 
 #ifdef WIN32
     // Enable away mode and prevent the sleep idle time-out.
-    SetThreadExecutionState(
-                            ES_CONTINUOUS 
-                            | ES_SYSTEM_REQUIRED
-    #ifdef _MSC_VER
+    SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED
+#ifdef _MSC_VER
                             | ES_AWAYMODE_REQUIRED
-    #endif
-                           );
+#endif
+    );
 #endif
 
-    if (semOutbound == NULL) 
+    if (semOutbound == NULL)
     {
         // initialize semaphore
-      //int nMaxOutbound = min(MAX_OUTBOUND_CONNECTIONS, (int)GetArg("-maxconnections", 125));
-        int nMaxOutbound = min( GetMaxOutboundConnections(), GetMaxConnections() );
+        // int nMaxOutbound = min(MAX_OUTBOUND_CONNECTIONS,
+        // (int)GetArg("-maxconnections", 125));
+        int nMaxOutbound = min(GetMaxOutboundConnections(), GetMaxConnections());
         semOutbound = new CSemaphore(nMaxOutbound);
     }
 
     if (pnodeLocalHost == NULL)
-        pnodeLocalHost = new CNode(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), nLocalServices));
+        pnodeLocalHost = new CNode(
+            INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), nLocalServices));
 
     Discover();
 
@@ -2906,9 +2752,8 @@ void StartNode(void* parg)
 
     if (!GetBoolArg("-dnsseed", true))
         printf("DNS seeding disabled\n");
-    else
-        if (!NewThread(ThreadDNSAddressSeed, NULL))
-            printf("Error: NewThread(ThreadDNSAddressSeed) failed\n");
+    else if (!NewThread(ThreadDNSAddressSeed, NULL))
+        printf("Error: NewThread(ThreadDNSAddressSeed) failed\n");
 
     // Map ports with UPnP
     if (!fUseUPnP)
@@ -2919,9 +2764,8 @@ void StartNode(void* parg)
     // Get addresses from IRC and advertise ours
     if (!GetBoolArg("-irc", true))
         printf("IRC seeding disabled\n");
-    else
-        if (!NewThread(ThreadIRCSeed, NULL))
-            printf("Error: NewThread(ThreadIRCSeed) failed\n");
+    else if (!NewThread(ThreadIRCSeed, NULL))
+        printf("Error: NewThread(ThreadIRCSeed) failed\n");
 
     // Send and receive from sockets, accept connections
     if (!NewThread(ThreadSocketHandler, NULL))
@@ -2943,7 +2787,8 @@ void StartNode(void* parg)
     if (!NewThread(ThreadDumpAddress, NULL))
         printf("Error; NewThread(ThreadDumpAddress) failed\n");
 
-    if (!pindexBest || (pindexBest->nHeight + 1) < nMainnetNewLogicBlockNumber)
+    if (!chainActive.Tip() ||
+        (chainActive.Tip()->nHeight + 1) < nMainnetNewLogicBlockNumber)
     {
         // ppcoin: mint proof-of-stake blocks in the background
         if (!NewThread(ThreadStakeMinter, pwalletMain))
@@ -2961,13 +2806,13 @@ bool StopNode()
     fShutdown = true;
 
 #ifdef WIN32
-    // Clear EXECUTION_STATE flags to disable away mode and allow the system to idle to sleep normally.
+    // Clear EXECUTION_STATE flags to disable away mode and allow the system to
+    // idle to sleep normally.
     SetThreadExecutionState(ES_CONTINUOUS);
 #endif
 
     ++nTransactionsUpdated;
-    ::int64_t 
-        nStart = GetTime();
+    ::int64_t nStart = GetTime();
     {
         LOCK(cs_main);
         ThreadScriptCheckQuit();
@@ -2981,110 +2826,102 @@ bool StopNode()
     }
     do
     {
-        int 
-            nThreadsRunning = 0;
+        int nThreadsRunning = 0;
 
         for (int n = 0; n < THREAD_MAX; ++n)
             nThreadsRunning += vnThreadsRunning[n];
         if (nThreadsRunning == 0)
             break;
-        if (GetTime() - nStart > 20) // if it takes more than 20 seconds then break?  Why
+        if (GetTime() - nStart >
+            20) // if it takes more than 20 seconds then break?  Why
             break;
-      //Sleep(20);                   // wait 20ms, then break, why?
+        // Sleep(20);                   // wait 20ms, then break, why?
         Sleep(2 * nTenMilliseconds);
-    } while(true);
+    } while (true);
 
-    if (vnThreadsRunning[THREAD_SOCKETHANDLER] > 0) 
+    if (vnThreadsRunning[THREAD_SOCKETHANDLER] > 0)
         printf("ThreadSocketHandler still running\n");
 
-    if (vnThreadsRunning[THREAD_OPENCONNECTIONS] > 0) 
+    if (vnThreadsRunning[THREAD_OPENCONNECTIONS] > 0)
         printf("ThreadOpenConnections still running\n");
 
-    if (vnThreadsRunning[THREAD_MESSAGEHANDLER] > 0) 
+    if (vnThreadsRunning[THREAD_MESSAGEHANDLER] > 0)
         printf("ThreadMessageHandler still running\n");
 
-    if (vnThreadsRunning[THREAD_RPCLISTENER] > 0) 
+    if (vnThreadsRunning[THREAD_RPCLISTENER] > 0)
         printf("ThreadRPCListener still running\n");
 
-    if (vnThreadsRunning[THREAD_RPCHANDLER] > 0) 
+    if (vnThreadsRunning[THREAD_RPCHANDLER] > 0)
         printf("ThreadsRPCServer still running\n");
 #ifdef USE_UPNP
-    if (vnThreadsRunning[THREAD_UPNP] > 0) 
+    if (vnThreadsRunning[THREAD_UPNP] > 0)
         printf("ThreadMapPort still running\n");
 #endif
 
-    if (vnThreadsRunning[THREAD_DNSSEED] > 0) 
+    if (vnThreadsRunning[THREAD_DNSSEED] > 0)
         printf("ThreadDNSAddressSeed still running\n");
 
-    if (vnThreadsRunning[THREAD_ADDEDCONNECTIONS] > 0) 
+    if (vnThreadsRunning[THREAD_ADDEDCONNECTIONS] > 0)
         printf("ThreadOpenAddedConnections still running\n");
 
-    if (vnThreadsRunning[THREAD_DUMPADDRESS] > 0) 
+    if (vnThreadsRunning[THREAD_DUMPADDRESS] > 0)
         printf("ThreadDumpAddresses still running\n");
 
-    if (vnThreadsRunning[THREAD_MINTER] > 0) 
+    if (vnThreadsRunning[THREAD_MINTER] > 0)
         printf("ThreadStakeMinter still running\n");
 
-    if (vnThreadsRunning[THREAD_SCRIPTCHECK] > 0) 
+    if (vnThreadsRunning[THREAD_SCRIPTCHECK] > 0)
         printf("ThreadScriptCheck still running\n");
 
-    while (
-        (vnThreadsRunning[THREAD_MESSAGEHANDLER] > 0) || 
-        (vnThreadsRunning[THREAD_RPCHANDLER] > 0) || 
-        (vnThreadsRunning[THREAD_SCRIPTCHECK] > 0) ||
-        (vnThreadsRunning[THREAD_ADDEDCONNECTIONS] > 0)
-          )
-      //Sleep(20);      // again, related to above?  Or not? Or ...???
-        Sleep(2 * nTenMilliseconds);      // again, related to above?  Or not? Or ...???
+    while ((vnThreadsRunning[THREAD_MESSAGEHANDLER] > 0) ||
+           (vnThreadsRunning[THREAD_RPCHANDLER] > 0) ||
+           (vnThreadsRunning[THREAD_SCRIPTCHECK] > 0) ||
+           (vnThreadsRunning[THREAD_ADDEDCONNECTIONS] > 0))
+        // Sleep(20);      // again, related to above?  Or not? Or ...???
+        Sleep(2 * nTenMilliseconds); // again, related to above?  Or not? Or ...???
 
-  //Sleep(50);
+    // Sleep(50);
     Sleep(5 * nTenMilliseconds);
     DumpAddresses();
-    return true;    // it seems it can only return true, so why not void!?
+    return true; // it seems it can only return true, so why not void!?
 }
 
 class CNetCleanup
 {
 public:
-    CNetCleanup()
-    {
-    }
+    CNetCleanup() {}
     ~CNetCleanup()
     {
         if (fDebug)
         {
 #ifdef _MSC_VER
             if (fPrintToConsole)
-                (void)printf(
-                             "~CNetCleanup() destructor called..."
-                            );
+                (void)printf("~CNetCleanup() destructor called...");
 #endif
         }
         // Close sockets
-        BOOST_FOREACH(CNode* pnode, vNodes)
+        BOOST_FOREACH (CNode *pnode, vNodes)
         {
             if (pnode->hSocket != INVALID_SOCKET)
             {
                 (void)closesocket(pnode->hSocket);
             }
         }
-        BOOST_FOREACH(SOCKET hListenSocket, vhListenSocket)
+        BOOST_FOREACH (SOCKET hListenSocket, vhListenSocket)
         {
             if (hListenSocket != INVALID_SOCKET)
             {
                 if (closesocket(hListenSocket) == SOCKET_ERROR)
                 {
-                    printf("closesocket(hListenSocket) failed with error %d\n", WSAGetLastError());
-                    clearLocalSocketError( hListenSocket ); //<<<<<<<<<<<<<only unguarded
+                    printf("closesocket(hListenSocket) failed with error %d\n",
+                           WSAGetLastError());
+                    clearLocalSocketError(hListenSocket); //<<<<<<<<<<<<<only unguarded
                 }
             }
         }
 #ifdef WIN32
         // Shutdown Windows Sockets
-        if( 
-            (0 != vhListenSocket.size()) ||
-            (0 != vNodes.size())
-          )
+        if ((0 != vhListenSocket.size()) || (0 != vNodes.size()))
         {
             WSACleanup();
         }
@@ -3093,15 +2930,16 @@ public:
         {
 #ifdef _MSC_VER
             if (fPrintToConsole)
-                (void)printf( " done\n" );
+                (void)printf(" done\n");
 #endif
-            Sleep( 2 * nMillisecondsPerSecond );    // 2 seconds just to see the 
-                                                    //message of who is the slowest to close
+            Sleep(2 *
+                  nMillisecondsPerSecond); // 2 seconds just to see the
+                                           // message of who is the slowest to close
         }
     }
 } instance_of_cnetcleanup;
 
-void RelayTransaction(const CTransaction& tx, const uint256& hash)
+void RelayTransaction(const CTransaction &tx, const uint256 &hash)
 {
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
     ss.reserve(10000);
@@ -3109,16 +2947,15 @@ void RelayTransaction(const CTransaction& tx, const uint256& hash)
     RelayTransaction(tx, hash, ss);
 }
 
-void RelayTransaction(const CTransaction& tx, const uint256& hash, const CDataStream& ss)
+void RelayTransaction(const CTransaction &tx, const uint256 &hash,
+                      const CDataStream &ss)
 {
     CInv inv(MSG_TX, hash);
     {
         LOCK(cs_mapRelay);
         // Expire old relay messages
-        while (
-               !vRelayExpiration.empty() && 
-               (vRelayExpiration.front().first < GetTime())
-              )
+        while (!vRelayExpiration.empty() &&
+               (vRelayExpiration.front().first < GetTime()))
         {
             mapRelay.erase(vRelayExpiration.front().second);
             vRelayExpiration.pop_front();
@@ -3156,5 +2993,5 @@ void CNode::RecordBytesSent(::uint64_t bytes)
     return nTotalBytesSent;
 }
 #ifdef _MSC_VER
-    #include "msvc_warnings.pop.h"
+#include "msvc_warnings.pop.h"
 #endif

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -43,9 +43,9 @@ double ClientModel::getPoSKernelPS()
 double ClientModel::getDifficulty(bool fProofofStake)
 {
     if (fProofofStake)
-       return GetDifficulty(GetLastBlockIndex(pindexBest,true));
+       return GetDifficulty(GetLastBlockIndex(chainActive.Tip(),true));
     else
-       return GetDifficulty(GetLastBlockIndex(pindexBest,false));
+       return GetDifficulty(GetLastBlockIndex(chainActive.Tip(),false));
 }
 
 int ClientModel::getNumConnections(uint8_t flags) const
@@ -64,7 +64,7 @@ int ClientModel::getNumConnections(uint8_t flags) const
 
 int ClientModel::getNumBlocks() const
 {
-    return nBestHeight;
+    return chainActive.Height();
 }
 
 int ClientModel::getNumBlocksAtStartup()
@@ -85,8 +85,8 @@ quint64 ClientModel::getTotalBytesSent() const
 
 QDateTime ClientModel::getLastBlockDate() const
 {
-    if (pindexBest)
-        return QDateTime::fromTime_t(pindexBest->GetBlockTime());
+    if (chainActive.Tip())
+        return QDateTime::fromTime_t(chainActive.Tip()->GetBlockTime());
     else
         return QDateTime::fromTime_t(1367991220); // Genesis block's time
 }
@@ -150,7 +150,7 @@ int ClientModel::getNumBlocksOfPeers() const
 
 int ClientModel::getNFactor() const
 {
-    return GetNfactor(pindexBest->GetBlockTime(), nBestHeight >= nMainnetNewLogicBlockNumber? true : false);
+    return GetNfactor(chainActive.Tip()->GetBlockTime(), chainActive.Height() >= nMainnetNewLogicBlockNumber? true : false);
 }
 
 QString ClientModel::getStatusBarWarnings() const

--- a/src/qt/explorer.cpp
+++ b/src/qt/explorer.cpp
@@ -304,7 +304,7 @@ void ExplorerPage::showBlockLineDetails( )
     {
         if ( 
             ( 0 <= nNewBlockNumber ) &&
-            ( nNewBlockNumber <= nBestHeight )
+            ( nNewBlockNumber <= chainActive.Height() )
            )
         {
             if ( nNewBlockNumber != nLastBestHeight )
@@ -883,7 +883,7 @@ std::string BuildTxDetailsFrom(
             {
                 sStandardItemModelElement = strprintf( 
                                                     "%d"
-                                                    , 1 + nBestHeight - pindex->nHeight 
+                                                    , 1 + chainActive.Height() - pindex->nHeight 
                                                      );
                 sTemp += sStandardItemModelElement + "<br />\n";
                 pQSIMtxinfo->setData( 
@@ -1186,7 +1186,7 @@ void ExplorerPage::setNumBlocks( int currentHeight )
             nSECONDsPerHOUR = nSECONDsPerMINUTE * nMINUTEsPerHOUR;
             
         // really should get the block determined from height parameter currentHeight
-        // but nBestHeight & hashBestChain refer to the best block, I think!?
+        // but chainActive.Height() & hashBestChain refer to the best block, I think!?
 
         int
             nHeight = currentHeight;

--- a/src/qt/mintingtablemodel.cpp
+++ b/src/qt/mintingtablemodel.cpp
@@ -405,7 +405,7 @@ QString MintingTableModel::lookupAddress(const std::string &address, bool toolti
 QString MintingTableModel::formatTxPoSReward(KernelRecord *wtx) const
 {
     QString posReward;
-    int nBits = GetLastBlockIndex(pindexBest, true)->nBits;
+    int nBits = GetLastBlockIndex(chainActive.Tip(), true)->nBits;
     posReward += QString(QObject::tr("from  %1 to %2")).arg(BitcoinUnits::formatWithUnit(walletModel->getOptionsModel()->getDisplayUnit(), wtx->getPoSReward(nBits, 0)), 
         BitcoinUnits::formatWithUnit(walletModel->getOptionsModel()->getDisplayUnit(), wtx->getPoSReward(nBits, mintingInterval))); 
     return posReward;
@@ -413,7 +413,7 @@ QString MintingTableModel::formatTxPoSReward(KernelRecord *wtx) const
 
 double MintingTableModel::getDayToMint(KernelRecord *wtx) const
 {
-    const CBlockIndex *p = GetLastBlockIndex(pindexBest, true);
+    const CBlockIndex *p = GetLastBlockIndex(chainActive.Tip(), true);
     double difficulty = GetDifficulty(p);
 
     double prob = wtx->getProbToMintWithinNMinutes(difficulty, mintingInterval);

--- a/src/qt/multisigdialog.cpp
+++ b/src/qt/multisigdialog.cpp
@@ -436,7 +436,8 @@ void MultisigDialog::on_signTransactionButton_clicked()
         bool fInvalid;
 
         tempTx.vin.push_back(mergedTx.vin[i]);
-        tempTx.FetchInputs(txdb, unused, false, false, mapPrevTx, fInvalid);
+        CValidationState state;
+        tempTx.FetchInputs(state, txdb, unused, false, false, mapPrevTx, fInvalid);
 
         BOOST_FOREACH(const CTxIn& txin, tempTx.vin)
         {
@@ -556,7 +557,8 @@ void MultisigDialog::on_sendTransactionButton_clicked()
 
     // Send the transaction to the local node
     CTxDB txdb("r");
-    if(!tx.AcceptToMemoryPool(txdb, false))
+	CValidationState state;
+    if(!tx.AcceptToMemoryPool(state, txdb, false))
     return;
     SyncWithWallets(tx, NULL, true);
     //(CInv(MSG_TX, txHash), tx);

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -17,7 +17,7 @@ QString TransactionDesc::FormatTxStatus(const CWalletTx& wtx)
     if (!wtx.IsFinal())
     {
         if (wtx.nLockTime < LOCKTIME_THRESHOLD)
-            return tr("Open for %n block(s)", "", nBestHeight - wtx.nLockTime);
+            return tr("Open for %n block(s)", "", chainActive.Height() - wtx.nLockTime);
         else
             return tr("Open until %1").arg(GUIUtil::dateTimeStr(wtx.nLockTime));
     }

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -199,14 +199,14 @@ void TransactionRecord::updateStatus(const CWalletTx &wtx)
         idx);                                                           // what index?
     status.confirmed = wtx.IsTrusted();
     status.depth = wtx.GetDepthInMainChain();
-    status.cur_num_blocks = nBestHeight;
+    status.cur_num_blocks = chainActive.Height();
 
     if (!wtx.IsFinal())
     {
         if (wtx.nLockTime < LOCKTIME_THRESHOLD)
         {
             status.status = TransactionStatus::OpenUntilBlock;
-            status.open_for = nBestHeight - wtx.nLockTime;
+            status.open_for = chainActive.Height() - wtx.nLockTime;
         }
         else
         {
@@ -265,7 +265,7 @@ void TransactionRecord::updateStatus(const CWalletTx &wtx)
 
 bool TransactionRecord::statusUpdateNeeded()
 {
-    return status.cur_num_blocks != nBestHeight;
+    return status.cur_num_blocks != chainActive.Height();
 }
 
 std::string TransactionRecord::getTxID()

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -275,9 +275,9 @@ void TransactionTableModel::updateTransaction(const QString &hash, int status)
 
 void TransactionTableModel::updateConfirmations()
 {
-    if(nBestHeight != cachedNumBlocks)
+    if(chainActive.Height() != cachedNumBlocks)
     {
-        cachedNumBlocks = nBestHeight;
+        cachedNumBlocks = chainActive.Height();
         // Blocks came in since last poll.
         // Invalidate status (number of confirmations) and (possibly) description
         //  for all rows. Qt is smart enough to only actually request the data for the

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -90,10 +90,10 @@ void WalletModel::updateStatus()
 
 void WalletModel::pollBalanceChanged()
 {
-    if(nBestHeight != cachedNumBlocks)
+    if(chainActive.Height() != cachedNumBlocks)
     {
         // Balance and number of transactions might have changed
-        cachedNumBlocks = nBestHeight;
+        cachedNumBlocks = chainActive.Height();
         checkBalanceChanged();
     }
 }

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -30,10 +30,10 @@ double GetDifficulty(const CBlockIndex* blockindex)
     // minimum difficulty = 1.0.
     if (blockindex == NULL)
     {
-        if (pindexBest == NULL)
+        if (chainActive.Tip() == NULL)
             return 1.0;
         else
-            blockindex = GetLastBlockIndex(pindexBest, false);
+            blockindex = GetLastBlockIndex(chainActive.Tip(), false);
     }
 
     int nShift = (blockindex->nBits >> 24) & 0xff;  // mask to top 8 bits
@@ -61,8 +61,8 @@ double GetPoWMHashPS()
     int nPoWInterval = 72;
     int64_t nTargetSpacingWorkMin = 30, nTargetSpacingWork = 30;
 
-    CBlockIndex* pindex = pindexGenesisBlock;
-    CBlockIndex* pindexPrevWork = pindexGenesisBlock;
+    CBlockIndex* pindex = chainActive.Genesis();
+    CBlockIndex* pindexPrevWork = chainActive.Genesis();
 
     while (pindex)
     {
@@ -86,7 +86,7 @@ double GetPoSKernelPS()
     double dStakeKernelsTriedAvg = 0;
     int nStakesHandled = 0, nStakesTime = 0;
 
-    CBlockIndex* pindex = pindexBest;;
+    CBlockIndex* pindex = chainActive.Tip();;
     CBlockIndex* pindexPrevStake = NULL;
 
     while (pindex && nStakesHandled < nPoSInterval)
@@ -137,7 +137,6 @@ Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool fPri
     result.push_back(Pair("entropybit", (int)blockindex->GetStakeEntropyBit()));
     result.push_back(Pair("modifier", strprintf("%016" PRIx64, blockindex->nStakeModifier)));
     result.push_back(Pair("modifierchecksum", strprintf("%08x", blockindex->nStakeModifierChecksum)));
-    result.push_back(Pair("posblocks", (int)blockindex->nPosBlockCount));
     Array txinfo;
     BOOST_FOREACH (const CTransaction& tx, block.vtx)
     {
@@ -171,6 +170,33 @@ Value getbestblockhash(const Array& params, bool fHelp)
     return hashBestChain.GetHex();
 }
 
+Value gettimechaininfo(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "gettimechaininfo\n"
+            "Returns an object containing various state info regarding block chain processing.\n"
+            "\nResult:\n"
+            "{\n"
+            "  \"chain\": \"xxxx\",        (string) current network name as defined in BIP70 (main, test, regtest)\n"
+            "  \"blocks\": xxxxxx,         (numeric) the current number of blocks processed in the server\n"
+            "  \"headers\": xxxxxx,        (numeric) the current number of headers we have validated\n"
+            "  \"bestblockhash\": \"...\", (string) the hash of the currently best block\n"
+            "  \"difficulty\": xxxxxx,     (numeric) the current difficulty\n"
+            "  \"verificationprogress\": xxxx, (numeric) estimate of verification progress [0..1]\n"
+            "  \"chainwork\": \"xxxx\"     (string) total amount of work in active chain, in hexadecimal\n"
+            "}\n"
+        );
+
+    Object obj;
+    obj.push_back(Pair("blocks",                (int)chainActive.Height()));
+    obj.push_back(Pair("headers",               pindexBestHeader ? pindexBestHeader->nHeight : -1));
+    obj.push_back(Pair("bestblockhash",         chainActive.Tip()->GetBlockHash().GetHex()));
+    obj.push_back(Pair("difficulty",            (double)GetDifficulty()));
+    obj.push_back(Pair("bnChainTrust",             chainActive.Tip()->bnChainTrust.getuint64()));
+    return obj;
+}
+
 Value getblockcount(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
@@ -178,7 +204,7 @@ Value getblockcount(const Array& params, bool fHelp)
             "getblockcount\n"
             "Returns the number of blocks in the longest block chain.");
 
-    return nBestHeight;
+    return chainActive.Height();
 }
 
 double doGetYACprice()
@@ -335,7 +361,7 @@ Value getcurrentblockandtime(const Array& params, bool fHelp)
                            );
 
     CBlockIndex
-        * pbi = FindBlockByHeight(nBestHeight);
+        * pbi = FindBlockByHeight(chainActive.Height());
 
     CBlock 
         block;
@@ -417,7 +443,7 @@ Value getcurrentblockandtime(const Array& params, bool fHelp)
                              "%d %s"
                              "\n"
                              "",
-                             int(nBestHeight),
+                             int(chainActive.Height()),
                              DateTimeStrFormat(
                                   " %Y-%m-%d %H:%M:%S",
                                   block.GetBlockTime()
@@ -440,7 +466,7 @@ Value getcurrentblockandtime(const Array& params, bool fHelp)
                          "%d %s (local %s)"
                          "\n"
                          "",
-                         int(nBestHeight),
+                         int(chainActive.Height()),
                          DateTimeStrFormat(
                               " %Y-%m-%d %H:%M:%S",
                               block.GetBlockTime()
@@ -461,7 +487,7 @@ Value getcurrentblockandtime(const Array& params, bool fHelp)
                      "%d %s (local %s)"
                      "\n"
                      "",
-                     int(nBestHeight),
+                     int(chainActive.Height()),
                      DateTimeStrFormat(
                           " %Y-%m-%d %H:%M:%S",
                           block.GetBlockTime()
@@ -482,13 +508,13 @@ Value getdifficulty(const Array& params, bool fHelp)
             "Returns the difficulty as a multiple of the minimum difficulty.");
 
     const CBlockIndex
-        *pindex = GetLastBlockIndex( pindexBest, false ); // means PoW block
+        *pindex = GetLastBlockIndex( chainActive.Tip(), false ); // means PoW block
     uint256
         nTarget = CBigNum().SetCompact( pindex->nBits ).getuint256();
 
     Object obj;
     obj.push_back(Pair("proof-of-work",        GetDifficulty()));
-    obj.push_back(Pair("proof-of-stake",       GetDifficulty(GetLastBlockIndex(pindexBest, true))));
+    obj.push_back(Pair("proof-of-stake",       GetDifficulty(GetLastBlockIndex(chainActive.Tip(), true))));
     obj.push_back(Pair("search-interval",      (int)nLastCoinStakeSearchInterval));
     obj.push_back(
                   Pair(
@@ -538,10 +564,10 @@ Value getblockhash(const Array& params, bool fHelp)
             "Returns hash of block in best-block-chain at <index>.");
 
     int nHeight = params[0].get_int();
-    if (nHeight < 0 || nHeight > nBestHeight)
+    if (nHeight < 0 || nHeight > chainActive.Height())
         throw runtime_error("Block number out of range.");
 
-    CBlockIndex* pblockindex = FindBlockByHeight(nHeight);
+    CBlockIndex* pblockindex = chainActive[nHeight];
     return pblockindex->phashBlock->GetHex();
 }
 
@@ -576,7 +602,7 @@ Value getblocktimes(const Array& params, bool fHelp)
                            );
     }
     int nNumber = params[0].get_int();
-    if ((nNumber < 1) || (nNumber > nBestHeight))   // maybe better is 2048?
+    if ((nNumber < 1) || (nNumber > chainActive.Height()))   // maybe better is 2048?
         throw runtime_error("Number of blocks is out of range.");
 
     CBlock block;
@@ -621,7 +647,7 @@ Value getblockbynumber(const Array& params, bool fHelp)
             "Returns details of a block with given block-number.");
 
     int nHeight = params[0].get_int();
-    if (nHeight < 0 || nHeight > nBestHeight)
+    if (nHeight < 0 || nHeight > chainActive.Height())
         throw runtime_error("Block number out of range.");
 
     CBlock block;

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -72,7 +72,7 @@ Value importprivkey(const Array& params, bool fHelp)
         if (!pwalletMain->AddKey(key))
             throw JSONRPCError(RPC_WALLET_ERROR, "Error adding key to wallet");
 
-        pwalletMain->ScanForWalletTransactions(pindexGenesisBlock, true);
+        pwalletMain->ScanForWalletTransactions(chainActive.Genesis(), true);
         pwalletMain->ReacceptWalletTransactions();
     }
 
@@ -125,7 +125,7 @@ Value importaddress(const Array& params, bool fHelp)
 
         if (fRescan)
         {
-            pwalletMain->ScanForWalletTransactions(pindexGenesisBlock, true);
+            pwalletMain->ScanForWalletTransactions(chainActive.Genesis(), true);
             pwalletMain->ReacceptWalletTransactions();
         }
     }

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -153,6 +153,8 @@ Value getpeerinfo(const Array& params, bool fHelp)
     BOOST_FOREACH(const CNodeStats& stats, vstats) {
         Object obj;
 
+        CNodeStateStats statestats;
+        bool fStateStats = GetNodeStateStats(stats.nodeid, statestats);
         obj.push_back(Pair("addr", stats.addrName));
         obj.push_back(Pair("services", strprintf("%08" PRIx64, stats.nServices)));
       //obj.push_back(Pair("lastsend", (boost::int64_t)stats.nLastSend));
@@ -168,9 +170,16 @@ Value getpeerinfo(const Array& params, bool fHelp)
         obj.push_back(Pair("inbound", stats.fInbound));
         obj.push_back(Pair("releasetime", (boost::int64_t)stats.nReleaseTime));
         obj.push_back(Pair("startingheight", stats.nStartingHeight));
-        obj.push_back(Pair("banscore", stats.nMisbehavior));
-        if (stats.fSyncNode)
-            obj.push_back(Pair("syncnode", true));
+        if (fStateStats) {
+            obj.push_back(Pair("banscore", statestats.nMisbehavior));
+            obj.push_back(Pair("synced_headers", statestats.nSyncHeight));
+            obj.push_back(Pair("synced_blocks", statestats.nCommonHeight));
+            Array heights;
+            BOOST_FOREACH(int height, statestats.vHeightInFlight) {
+                heights.push_back(height);
+            }
+            obj.push_back(Pair("inflight", heights));
+        }
         ret.push_back(obj);
     }
     Object 

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -109,7 +109,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, Object& entry)
             CBlockIndex* pindex = (*mi).second;
             if (pindex->IsInMainChain())
             {
-                entry.push_back(Pair("confirmations", 1 + nBestHeight - pindex->nHeight));
+                entry.push_back(Pair("confirmations", 1 + chainActive.Height() - pindex->nHeight));
                 entry.push_back(Pair("blocktime", (boost::int64_t)pindex->nTime));
             }
             else
@@ -406,8 +406,9 @@ Value signrawtransaction(const Array& params, bool fHelp)
         bool fInvalid;
 
         // FetchInputs aborts on failure, so we go one at a time.
+        CValidationState state;
         tempTx.vin.push_back(mergedTx.vin[i]);
-        tempTx.FetchInputs(txdb, unused, false, false, mapPrevTx, fInvalid);
+        tempTx.FetchInputs(state, txdb, unused, false, false, mapPrevTx, fInvalid);
 
         // Copy results into mapPrevOut:
         BOOST_FOREACH(const CTxIn& txin, tempTx.vin)
@@ -596,7 +597,8 @@ Value sendrawtransaction(const Array& params, bool fHelp)
     {
         // push to local node
         CTxDB txdb("r");
-        if (!tx.AcceptToMemoryPool(txdb))
+        CValidationState state;
+        if (!tx.AcceptToMemoryPool(state, txdb))
             throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX rejected");
 
         SyncWithWallets(tx, NULL, true);

--- a/src/scrypt.cpp
+++ b/src/scrypt.cpp
@@ -319,7 +319,7 @@ const ::uint32_t
     #endif
 #endif
             if (
-                (pindexPrev != pindexBest) ||
+                (pindexPrev != chainActive.Tip()) ||
                 fShutdown
                )
                 break;

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -63,10 +63,10 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     for (unsigned int i = 0; i < sizeof(blockinfo)/sizeof(*blockinfo); ++i)
     {
         pblock->nVersion = 1;
-        pblock->nTime = pindexBest->GetMedianTimePast()+1;
+        pblock->nTime = chainActive.Tip()->GetMedianTimePast()+1;
         pblock->vtx[0].vin[0].scriptSig = CScript();
         pblock->vtx[0].vin[0].scriptSig.push_back(blockinfo[i].extranonce);
-        pblock->vtx[0].vin[0].scriptSig.push_back(pindexBest->nHeight);
+        pblock->vtx[0].vin[0].scriptSig.push_back(chainActive.Tip()->nHeight);
         pblock->vtx[0].vout[0].scriptPubKey = CScript();
         if (txFirst.size() < 2)
             txFirst.push_back(new CTransaction(pblock->vtx[0]));
@@ -188,14 +188,14 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     mempool.clear();
 
     // subsidy changing
-    int nHeight = pindexBest->nHeight;
-    pindexBest->nHeight = 209999;
+    int nHeight = chainActive.Tip()->nHeight;
+    chainActive.Tip()->nHeight = 209999;
     BOOST_CHECK(pblock = CreateNewBlock(reservekey));
     delete pblock;
-    pindexBest->nHeight = 210000;
+    chainActive.Tip()->nHeight = 210000;
     BOOST_CHECK(pblock = CreateNewBlock(reservekey));
     delete pblock;
-    pindexBest->nHeight = nHeight;
+    chainActive.Tip()->nHeight = nHeight;
 }
 
 BOOST_AUTO_TEST_CASE(sha256transform_equality)

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -66,8 +66,8 @@ BOOST_AUTO_TEST_CASE(tx_valid)
             CDataStream stream(ParseHex(transaction), SER_NETWORK, PROTOCOL_VERSION);
             CTransaction tx;
             stream >> tx;
-
-                BOOST_CHECK_MESSAGE(tx.CheckTransaction(), strTest);
+            CValidationState state;
+                BOOST_CHECK_MESSAGE(tx.CheckTransaction(state), strTest);
 
             for (unsigned int i = 0; i < tx.vin.size(); i++)
             {
@@ -135,8 +135,8 @@ BOOST_AUTO_TEST_CASE(tx_invalid)
             CDataStream stream(ParseHex(transaction), SER_NETWORK, PROTOCOL_VERSION);
             CTransaction tx;
             stream >> tx;
-
-            fValid = tx.CheckTransaction();
+            CValidationState state;
+            fValid = tx.CheckTransaction(state);
 
             for (unsigned int i = 0; i < tx.vin.size() && fValid; i++)
             {
@@ -162,7 +162,8 @@ BOOST_AUTO_TEST_CASE(basic_transaction_tests)
     CDataStream stream(vch, SER_DISK, CLIENT_VERSION);
     CTransaction tx;
     stream >> tx;
-    BOOST_CHECK_MESSAGE(tx.CheckTransaction(), "Simple deserialized transaction should be valid.");
+    CValidationState state;
+    BOOST_CHECK_MESSAGE(tx.CheckTransaction(state), "Simple deserialized transaction should be valid.");
 
     // Check that duplicate txins fail
     tx.vin.push_back(tx.vin[0]);

--- a/src/txdb-bdb.cpp
+++ b/src/txdb-bdb.cpp
@@ -213,18 +213,17 @@ bool CTxDB::LoadBlockIndex()
     // Load hashBestChain pointer to end of best chain
     if (!ReadHashBestChain(hashBestChain))
     {
-        if (pindexGenesisBlock == NULL)
+        if (chainActive.Genesis() == NULL)
             return true;
         return error("CTxDB::LoadBlockIndex() : hashBestChain not loaded");
     }
     if (!mapBlockIndex.count(hashBestChain))
         return error("CTxDB::LoadBlockIndex() : hashBestChain not found in the block index");
-    pindexBest = mapBlockIndex[hashBestChain];
-    nBestHeight = pindexBest->nHeight;
-    bnBestChainTrust = pindexBest->bnChainTrust;
+    chainActive.SetTip(mapBlockIndex[hashBestChain]);
+    bnBestChainTrust = chainActive.Tip()->bnChainTrust;
     printf("LoadBlockIndex(): hashBestChain=%s  height=%d  trust=%s  date=%s\n",
-      hashBestChain.ToString().substr(0,20).c_str(), nBestHeight, bnBestChainTrust.ToString().c_str(),
-      DateTimeStrFormat("%x %H:%M:%S", pindexBest->GetBlockTime()).c_str());
+      hashBestChain.ToString().substr(0,20).c_str(), chainActive.Height(), bnBestChainTrust.ToString().c_str(),
+      DateTimeStrFormat("%x %H:%M:%S", chainActive.Tip()->GetBlockTime()).c_str());
 
     // ppcoin: load hashSyncCheckpoint
     if (!ReadSyncCheckpoint(Checkpoints::hashSyncCheckpoint))
@@ -232,21 +231,21 @@ bool CTxDB::LoadBlockIndex()
     printf("LoadBlockIndex(): synchronized checkpoint %s\n", Checkpoints::hashSyncCheckpoint.ToString().c_str());
 
     // Load bnBestInvalidTrust, OK if it doesn't exist
-    ReadBestInvalidTrust(bnBestInvalidTrust);
+//    ReadBestInvalidTrust(bnBestInvalidTrust);
 
     // Verify blocks in the best chain
     int nCheckLevel = GetArg("-checklevel", 1);
     int nCheckDepth = GetArg( "-checkblocks", 750);
     if (nCheckDepth == 0)
         nCheckDepth = 1000000000; // suffices until the year 19000
-    if (nCheckDepth > nBestHeight)
-        nCheckDepth = nBestHeight;
+    if (nCheckDepth > chainActive.Height())
+        nCheckDepth = chainActive.Height();
     printf("Verifying last %i blocks at level %i\n", nCheckDepth, nCheckLevel);
     CBlockIndex* pindexFork = NULL;
     map<pair<unsigned int, unsigned int>, CBlockIndex*> mapBlockPos;
-    for (CBlockIndex* pindex = pindexBest; pindex && pindex->pprev; pindex = pindex->pprev)
+    for (CBlockIndex* pindex = chainActive.Tip(); pindex && pindex->pprev; pindex = pindex->pprev)
     {
-        if (fRequestShutdown || pindex->nHeight < nBestHeight-nCheckDepth)
+        if (fRequestShutdown || pindex->nHeight < chainActive.Height()-nCheckDepth)
             break;
         CBlock block;
         if (!block.ReadFromDisk(pindex))
@@ -360,8 +359,10 @@ bool CTxDB::LoadBlockIndex()
         CBlock block;
         if (!block.ReadFromDisk(pindexFork))
             return error("LoadBlockIndex() : block.ReadFromDisk failed");
+        setBlockIndexCandidates.insert(pindexFork);
         CTxDB txdb;
-        block.SetBestChain(txdb, pindexFork);
+        CValidationState state;
+        ActivateBestChain(state, txdb);
     }
 
     return true;
@@ -425,15 +426,11 @@ bool CTxDB::LoadBlockIndexGuts()
             pindexNew->nNonce         = diskindex.nNonce;
 
             // Watch for genesis block
-            if (pindexGenesisBlock == NULL && blockHash == (!fTestNet ? hashGenesisBlock : hashGenesisBlockTestNet))
-                pindexGenesisBlock = pindexNew;
+            if (chainActive.Genesis() == NULL && blockHash == (!fTestNet ? hashGenesisBlock : hashGenesisBlockTestNet))
+                chainActive.SetTip(pindexNew);
 
             if (!pindexNew->CheckIndex())
                 return error("LoadBlockIndex() : CheckIndex failed at %d", pindexNew->nHeight);
-
-            // ppcoin: build setStakeSeen
-            if (pindexNew->IsProofOfStake())
-                setStakeSeen.insert(make_pair(pindexNew->prevoutStake, pindexNew->nStakeTime));
         }
         else
         {

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -2,23 +2,22 @@
 // Copyright (c) 2009-2012 The Bitcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
-#ifdef USE_LEVELDB
 #ifdef _MSC_VER
-    #include <stdint.h>
+#include <stdint.h>
 
-    #include "msvc_warnings.push.h"
+#include "msvc_warnings.push.h"
 #endif
 
 #ifndef BITCOIN_CHECKPOINT_H
- #include "checkpoints.h"
+#include "checkpoints.h"
 #endif
 
 #ifndef BITCOIN_TXDB_H
- #include "txdb.h"
+#include "txdb.h"
 #endif
 
 #ifndef PPCOIN_KERNEL_H
- #include "kernel.h"
+#include "kernel.h"
 #endif
 
 #include <map>
@@ -34,16 +33,17 @@
 
 using namespace boost;
 
-using std::string;
-using std::runtime_error;
 using std::make_pair;
 using std::map;
 using std::pair;
+using std::runtime_error;
+using std::string;
 using std::vector;
 
 leveldb::DB *txdb; // global pointer for LevelDB object instance
 
-static leveldb::Options GetOptions() {
+static leveldb::Options GetOptions()
+{
     leveldb::Options options;
     int nCacheSizeMB = GetArg("-dbcache", 25);
     options.block_cache = leveldb::NewLRUCache(nCacheSizeMB * 1048576);
@@ -51,11 +51,13 @@ static leveldb::Options GetOptions() {
     return options;
 }
 
-void init_blockindex(leveldb::Options& options, bool fRemoveOld = false) {
+void init_blockindex(leveldb::Options &options, bool fRemoveOld = false)
+{
     // First time init.
     filesystem::path directory = GetDataDir() / "txleveldb";
 
-    if (fRemoveOld) {
+    if (fRemoveOld)
+    {
         filesystem::remove_all(directory); // remove directory
         unsigned int nFile = 1;
 
@@ -64,7 +66,7 @@ void init_blockindex(leveldb::Options& options, bool fRemoveOld = false) {
             filesystem::path strBlockFile = GetDataDir() / strprintf("blk%04u.dat", nFile);
 
             // Break if no such file
-            if( !filesystem::exists( strBlockFile ) )
+            if (!filesystem::exists(strBlockFile))
                 break;
 
             filesystem::remove(strBlockFile);
@@ -76,20 +78,22 @@ void init_blockindex(leveldb::Options& options, bool fRemoveOld = false) {
     filesystem::create_directory(directory);
     printf("Opening LevelDB in %s\n", directory.string().c_str());
     leveldb::Status status = leveldb::DB::Open(options, directory.string(), &txdb);
-    if (!status.ok()) {
+    if (!status.ok())
+    {
         throw runtime_error(strprintf("init_blockindex(): error opening database environment %s", status.ToString().c_str()));
     }
 }
 
 // CDB subclasses are created and destroyed VERY OFTEN. That's why
 // we shouldn't treat this as a free operations.
-CTxDB::CTxDB(const char* pszMode)
+CTxDB::CTxDB(const char *pszMode)
 {
     Yassert(pszMode);
     activeBatch = NULL;
     fReadOnly = (!strchr(pszMode, '+') && !strchr(pszMode, 'w'));
 
-    if (txdb) {
+    if (txdb)
+    {
         pdb = txdb;
         return;
     }
@@ -163,14 +167,16 @@ bool CTxDB::TxnCommit()
     leveldb::Status status = pdb->Write(leveldb::WriteOptions(), activeBatch);
     delete activeBatch;
     activeBatch = NULL;
-    if (!status.ok()) {
+    if (!status.ok())
+    {
         printf("LevelDB batch commit failure: %s\n", status.ToString().c_str());
         return false;
     }
     return true;
 }
 
-class CBatchScanner : public leveldb::WriteBatch::Handler {
+class CBatchScanner : public leveldb::WriteBatch::Handler
+{
 public:
     std::string needle;
     bool *deleted;
@@ -179,16 +185,20 @@ public:
 
     CBatchScanner() : foundEntry(false) {}
 
-    virtual void Put(const leveldb::Slice& key, const leveldb::Slice& value) {
-        if (key.ToString() == needle) {
+    virtual void Put(const leveldb::Slice &key, const leveldb::Slice &value)
+    {
+        if (key.ToString() == needle)
+        {
             foundEntry = true;
             *deleted = false;
             *foundValue = value.ToString();
         }
     }
 
-    virtual void Delete(const leveldb::Slice& key) {
-        if (key.ToString() == needle) {
+    virtual void Delete(const leveldb::Slice &key)
+    {
+        if (key.ToString() == needle)
+        {
             foundEntry = true;
             *deleted = true;
         }
@@ -200,7 +210,8 @@ public:
 // a database transaction begins reads are consistent with it. It would be good
 // to change that assumption in future and avoid the performance hit, though in
 // practice it does not appear to be large.
-bool CTxDB::ScanBatch(const CDataStream &key, string *value, bool *deleted) const {
+bool CTxDB::ScanBatch(const CDataStream &key, string *value, bool *deleted) const
+{
     Yassert(activeBatch);
     *deleted = false;
     CBatchScanner scanner;
@@ -208,26 +219,27 @@ bool CTxDB::ScanBatch(const CDataStream &key, string *value, bool *deleted) cons
     scanner.deleted = deleted;
     scanner.foundValue = value;
     leveldb::Status status = activeBatch->Iterate(&scanner);
-    if (!status.ok()) {
+    if (!status.ok())
+    {
         throw runtime_error(status.ToString());
     }
     return scanner.foundEntry;
 }
 
-bool CTxDB::ReadTxIndex(uint256 hash, CTxIndex& txindex)
+bool CTxDB::ReadTxIndex(uint256 hash, CTxIndex &txindex)
 {
     Yassert(!fClient);
     txindex.SetNull();
     return Read(make_pair(string("tx"), hash), txindex);
 }
 
-bool CTxDB::UpdateTxIndex(uint256 hash, const CTxIndex& txindex)
+bool CTxDB::UpdateTxIndex(uint256 hash, const CTxIndex &txindex)
 {
     Yassert(!fClient);
     return Write(make_pair(string("tx"), hash), txindex);
 }
 
-bool CTxDB::AddTxIndex(const CTransaction& tx, const CDiskTxPos& pos, int nHeight)
+bool CTxDB::AddTxIndex(const CTransaction &tx, const CDiskTxPos &pos, int nHeight)
 {
     Yassert(!fClient);
     // Add to tx index
@@ -236,7 +248,7 @@ bool CTxDB::AddTxIndex(const CTransaction& tx, const CDiskTxPos& pos, int nHeigh
     return Write(make_pair(string("tx"), hash), txindex);
 }
 
-bool CTxDB::EraseTxIndex(const CTransaction& tx)
+bool CTxDB::EraseTxIndex(const CTransaction &tx)
 {
     Yassert(!fClient);
     uint256 hash = tx.GetHash();
@@ -250,7 +262,7 @@ bool CTxDB::ContainsTx(uint256 hash)
     return Exists(make_pair(string("tx"), hash));
 }
 
-bool CTxDB::ReadDiskTx(uint256 hash, CTransaction& tx, CTxIndex& txindex)
+bool CTxDB::ReadDiskTx(uint256 hash, CTransaction &tx, CTxIndex &txindex)
 {
     Yassert(!fClient);
     tx.SetNull();
@@ -259,39 +271,39 @@ bool CTxDB::ReadDiskTx(uint256 hash, CTransaction& tx, CTxIndex& txindex)
     return (tx.ReadFromDisk(txindex.pos));
 }
 
-bool CTxDB::ReadDiskTx(uint256 hash, CTransaction& tx)
+bool CTxDB::ReadDiskTx(uint256 hash, CTransaction &tx)
 {
     CTxIndex txindex;
     return ReadDiskTx(hash, tx, txindex);
 }
 
-bool CTxDB::ReadDiskTx(COutPoint outpoint, CTransaction& tx, CTxIndex& txindex)
+bool CTxDB::ReadDiskTx(COutPoint outpoint, CTransaction &tx, CTxIndex &txindex)
 {
     return ReadDiskTx(outpoint.COutPointGetHash(), tx, txindex);
 }
 
-bool CTxDB::ReadDiskTx(COutPoint outpoint, CTransaction& tx)
+bool CTxDB::ReadDiskTx(COutPoint outpoint, CTransaction &tx)
 {
     CTxIndex txindex;
     return ReadDiskTx(outpoint.COutPointGetHash(), tx, txindex);
 }
 
-bool CTxDB::WriteBlockIndex(const CDiskBlockIndex& blockindex)
+bool CTxDB::WriteBlockIndex(const CDiskBlockIndex &blockindex)
 {
     return Write(make_pair(string("blockindex"), blockindex.GetBlockHash()), blockindex);
 }
 
-bool CTxDB::WriteBlockHash(const CDiskBlockIndex& blockindex)
+bool CTxDB::WriteBlockHash(const CDiskBlockIndex &blockindex)
 {
     return Write(make_pair(string("blockhash"), make_pair(blockindex.nFile, blockindex.nBlockPos)), blockindex.GetBlockHash());
 }
 
-bool CTxDB::ReadBlockHash(const unsigned int nFile, const unsigned int nBlockPos, uint256& blockhash)
+bool CTxDB::ReadBlockHash(const unsigned int nFile, const unsigned int nBlockPos, uint256 &blockhash)
 {
     return Read(make_pair(string("blockhash"), make_pair(nFile, nBlockPos)), blockhash);
 }
 
-bool CTxDB::ReadHashBestChain(uint256& hashBestChain)
+bool CTxDB::ReadHashBestChain(uint256 &hashBestChain)
 {
     return Read(string("hashBestChain"), hashBestChain);
 }
@@ -301,7 +313,7 @@ bool CTxDB::WriteHashBestChain(uint256 hashBestChain)
     return Write(string("hashBestChain"), hashBestChain);
 }
 
-bool CTxDB::ReadBestInvalidTrust(CBigNum& bnBestInvalidTrust)
+bool CTxDB::ReadBestInvalidTrust(CBigNum &bnBestInvalidTrust)
 {
     return Read(string("bnBestInvalidTrust"), bnBestInvalidTrust);
 }
@@ -311,7 +323,7 @@ bool CTxDB::WriteBestInvalidTrust(CBigNum bnBestInvalidTrust)
     return Write(string("bnBestInvalidTrust"), bnBestInvalidTrust);
 }
 
-bool CTxDB::ReadSyncCheckpoint(uint256& hashCheckpoint)
+bool CTxDB::ReadSyncCheckpoint(uint256 &hashCheckpoint)
 {
     return Read(string("hashSyncCheckpoint"), hashCheckpoint);
 }
@@ -321,38 +333,38 @@ bool CTxDB::WriteSyncCheckpoint(uint256 hashCheckpoint)
     return Write(string("hashSyncCheckpoint"), hashCheckpoint);
 }
 
-bool CTxDB::ReadCheckpointPubKey(string& strPubKey)
+bool CTxDB::ReadCheckpointPubKey(string &strPubKey)
 {
     return Read(string("strCheckpointPubKey"), strPubKey);
 }
 
-bool CTxDB::WriteCheckpointPubKey(const string& strPubKey)
+bool CTxDB::WriteCheckpointPubKey(const string &strPubKey)
 {
     return Write(string("strCheckpointPubKey"), strPubKey);
 }
 
-bool CTxDB::ReadModifierUpgradeTime(unsigned int& nUpgradeTime)
+bool CTxDB::ReadModifierUpgradeTime(unsigned int &nUpgradeTime)
 {
     return Read(string("nUpgradeTime"), nUpgradeTime);
 }
 
-bool CTxDB::WriteModifierUpgradeTime(const unsigned int& nUpgradeTime)
+bool CTxDB::WriteModifierUpgradeTime(const unsigned int &nUpgradeTime)
 {
     return Write(string("nUpgradeTime"), nUpgradeTime);
 }
 
 static CBlockIndex *InsertBlockIndex(uint256 hash)
-{   // this is the slow poke in start up load block index
+{ // this is the slow poke in start up load block index
     if (hash == 0)
         return NULL;
 
     // Return existing, presume this is slow?
-    map<uint256, CBlockIndex*>::iterator mi = mapBlockIndex.find(hash);
+    map<uint256, CBlockIndex *>::iterator mi = mapBlockIndex.find(hash);
     if (mi != mapBlockIndex.end())
         return (*mi).second;
 
     // Create new
-    CBlockIndex* pindexNew = new CBlockIndex();
+    CBlockIndex *pindexNew = new CBlockIndex();
     if (!pindexNew)
         throw runtime_error("LoadBlockIndex() : new CBlockIndex failed");
 
@@ -365,76 +377,76 @@ static CBlockIndex *InsertBlockIndex(uint256 hash)
 bool CTxDB::LoadBlockIndex()
 {
     if (
-        !(mapBlockIndex.empty())
-       ) 
-    {   // Already loaded. But, it can happen during migration from BDB.
+        !(mapBlockIndex.empty()))
+    { // Already loaded. But, it can happen during migration from BDB.
         return true;
     }
     // need a RAII class to fiddle fPrintToConsole to true if QT_GUI is defined
     // saving it and restoring it at function exit
-     #ifdef QT_GUI
-     class QCtFiddlefPTC
-     {
-     public:
-        QCtFiddlefPTC() : fSaved( fPrintToConsole ) { fPrintToConsole = true;}
-        ~QCtFiddlefPTC(){ fPrintToConsole = fSaved; }
-     private:
+#ifdef QT_GUI
+    class QCtFiddlefPTC
+    {
+    public:
+        QCtFiddlefPTC() : fSaved(fPrintToConsole) { fPrintToConsole = true; }
+        ~QCtFiddlefPTC() { fPrintToConsole = fSaved; }
+
+    private:
         bool fSaved;
-     } Junk;
-     #endif
+    } Junk;
+#endif
 #ifdef WIN32
     const int
 #ifdef Yac1dot0
-  #ifdef _DEBUG
-        nREFRESH = 10;    // generally resfresh rates are chosen to give ~1 update/sec
-  #else
+#ifdef _DEBUG
+        nREFRESH = 10; // generally resfresh rates are chosen to give ~1 update/sec
+#else
         // seems to be slowing down??
         nREFRESH = 20;
-  #endif
+#endif
 #else
-  #ifdef _DEBUG
-        nREFRESH = 2000;    // generally resfresh rates are chosen to give ~1 update/sec
-  #else
+#ifdef _DEBUG
+        nREFRESH = 2000; // generally resfresh rates are chosen to give ~1 update/sec
+#else
         // seems to be slowing down??
         nREFRESH = 12000;
-  #endif
+#endif
 #endif
     int
         nMaxHeightGuess = 1,
         nCounter = 0,
         nRefresh = nREFRESH;
     ::int64_t
-        n64timeStart, 
+        n64timeStart,
         nDelta1 = 0,
-        n64timeStart1, 
+        n64timeStart1,
         nDelta2 = 0,
-        n64timeStart2, 
+        n64timeStart2,
         nDelta3 = 0,
-        n64timeStart3, 
+        n64timeStart3,
         nDelta4 = 0,
-        n64timeStart4, 
+        n64timeStart4,
         nDelta5 = 0,
-        n64timeStart5, 
+        n64timeStart5,
         nDelta6 = 0,
-        n64timeStart6, 
+        n64timeStart6,
         nDelta7 = 0,
-        n64timeStart7, 
+        n64timeStart7,
         nDelta8 = 0,
-        n64timeStart8, 
+        n64timeStart8,
         nDelta9 = 0,
-        n64timeStart9, 
+        n64timeStart9,
         nDelta10 = 0,
-        n64timeStart10, 
+        n64timeStart10,
         nDelta11 = 0,
-        n64timeStart11, 
-        n64timeEnd, 
+        n64timeStart11,
+        n64timeEnd,
         n64deltaT = 0,
         n64MsStartTime = GetTimeMillis();
 #endif
     // The block index is an in-memory structure that maps hashes to on-disk
     // locations where the contents of the block can be found. Here, we scan it
     // out of the DB and into mapBlockIndex.
-    leveldb::Iterator 
+    leveldb::Iterator
         *iterator = pdb->NewIterator(leveldb::ReadOptions());
     // Seek to start key.
 
@@ -446,126 +458,138 @@ bool CTxDB::LoadBlockIndex()
     int newStoredBlock = 0;
     int alreadyStoredBlock = 0;
     // Now read each entry.
-    while (iterator->Valid())   //what is so slow in this loop of all PoW blocks?
-    {                           // 5 minutes for 1400 blocks, ~300 blocks/min or ~5/sec
+    while (iterator->Valid()) //what is so slow in this loop of all PoW blocks?
+    {                         // 5 minutes for 1400 blocks, ~300 blocks/min or ~5/sec
 #ifdef WIN32
         n64timeStart = GetTimeMillis();
 #endif
 
         // Unpack keys and values.
-        CDataStream 
+        CDataStream
             ssKey(SER_DISK, CLIENT_VERSION);
 
 #ifdef WIN32
-        n64timeStart1 = GetTimeMillis(); 
+        n64timeStart1 = GetTimeMillis();
         nDelta1 += (n64timeStart1 - n64timeStart);
 #endif
         ssKey.write(iterator->key().data(), iterator->key().size());
 
 #ifdef WIN32
-        n64timeStart2 = GetTimeMillis(); 
+        n64timeStart2 = GetTimeMillis();
         nDelta2 += (n64timeStart2 - n64timeStart1);
 #endif
-        CDataStream 
+        CDataStream
             ssValue(SER_DISK, CLIENT_VERSION);
 
 #ifdef WIN32
-        n64timeStart3 = GetTimeMillis(); 
+        n64timeStart3 = GetTimeMillis();
         nDelta3 += (n64timeStart3 - n64timeStart2);
 #endif
         ssValue.write(iterator->value().data(), iterator->value().size());
 
 #ifdef WIN32
-        n64timeStart4 = GetTimeMillis(); 
+        n64timeStart4 = GetTimeMillis();
         nDelta4 += (n64timeStart4 - n64timeStart3);
 #endif
-        string 
+        string
             strType;
 
         ssKey >> strType;
         // Did we reach the end of the data to read?
         if (fRequestShutdown || strType != "blockindex")
             break;
-        
+
 #ifdef WIN32
-        n64timeStart5 = GetTimeMillis(); 
+        n64timeStart5 = GetTimeMillis();
         nDelta5 += (n64timeStart5 - n64timeStart4);
 #endif
-        CDiskBlockIndex 
+        CDiskBlockIndex
             diskindex;
 
 #ifdef WIN32
-        n64timeStart6 = GetTimeMillis(); 
+        n64timeStart6 = GetTimeMillis();
         nDelta6 += (n64timeStart6 - n64timeStart5);
 #endif
         ssValue >> diskindex;
 
 #ifdef WIN32
-        n64timeStart7 = GetTimeMillis(); 
+        n64timeStart7 = GetTimeMillis();
         nDelta7 += (n64timeStart7 - n64timeStart6);
 #endif
-        uint256 
-            blockHash = diskindex.GetBlockHash();   // the slow poke!
+        uint256
+            blockHash = diskindex.GetBlockHash(); // the slow poke!
 
-        if ( 0 == blockHash )
+        if (0 == blockHash)
         {
             if (fPrintToConsole)
-                (void)printf( 
-                            "Error? at nHeight=%d"
-                            "\n"
-                            "",
-                            diskindex.nHeight
-                            );
-            continue;   //?
-
+                (void)printf(
+                    "Error? at nHeight=%d"
+                    "\n"
+                    "",
+                    diskindex.nHeight);
+            continue; //?
         }
 
 #ifdef WIN32
-        n64timeStart8 = GetTimeMillis(); 
+        n64timeStart8 = GetTimeMillis();
         nDelta8 += (n64timeStart8 - n64timeStart7);
 #endif
         // Construct block index object
         CBlockIndex
-            * pindexNew    = InsertBlockIndex(blockHash);
+            *pindexNew = InsertBlockIndex(blockHash);
         // what if null? Can't be, since blockhash is known to be != 0
-        if( NULL == pindexNew ) // ???
+        if (NULL == pindexNew) // ???
         {
             if (fPrintToConsole)
-                (void)printf( 
-                            "Error? InsertBlockIndex(...) failed"
-                            "\n"
-                            ""
-                            );
-            iterator->Next();        
+                (void)printf(
+                    "Error? InsertBlockIndex(...) failed"
+                    "\n"
+                    "");
+            iterator->Next();
             continue;
         }
-        pindexNew->pprev          = InsertBlockIndex(diskindex.hashPrev);
+        pindexNew->pprev = InsertBlockIndex(diskindex.hashPrev);
 
 #ifdef WIN32
-        n64timeStart9 = GetTimeMillis(); 
+        n64timeStart9 = GetTimeMillis();
         nDelta9 += (n64timeStart9 - n64timeStart8);
 #endif
-        pindexNew->pnext          = InsertBlockIndex(diskindex.hashNext);
+        pindexNew->pnext = InsertBlockIndex(diskindex.hashNext);
 
 #ifdef WIN32
-        n64timeStart10 = GetTimeMillis(); 
+        n64timeStart10 = GetTimeMillis();
         nDelta10 += (n64timeStart10 - n64timeStart9);
 #endif
-        pindexNew->nFile          = diskindex.nFile;
-        pindexNew->nBlockPos      = diskindex.nBlockPos;
-        pindexNew->nHeight        = diskindex.nHeight;
-        pindexNew->nMint          = diskindex.nMint;
-        pindexNew->nMoneySupply   = diskindex.nMoneySupply;
-        pindexNew->nFlags         = diskindex.nFlags;
+        pindexNew->nFile = diskindex.nFile;
+        pindexNew->nBlockPos = diskindex.nBlockPos;
+        pindexNew->nHeight = diskindex.nHeight;
+        pindexNew->nMint = diskindex.nMint;
+        pindexNew->nMoneySupply = diskindex.nMoneySupply;
+        pindexNew->nFlags = diskindex.nFlags;
         pindexNew->nStakeModifier = diskindex.nStakeModifier;
-        pindexNew->prevoutStake   = diskindex.prevoutStake;
-        pindexNew->nStakeTime     = diskindex.nStakeTime;
+        pindexNew->prevoutStake = diskindex.prevoutStake;
+        pindexNew->nStakeTime = diskindex.nStakeTime;
         pindexNew->hashProofOfStake = diskindex.hashProofOfStake;
-        pindexNew->nVersion       = diskindex.nVersion;
+        pindexNew->nVersion = diskindex.nVersion;
         pindexNew->hashMerkleRoot = diskindex.hashMerkleRoot;
-        pindexNew->nTime          = diskindex.nTime;
-        pindexNew->nBits          = diskindex.nBits;
-        pindexNew->nNonce         = diskindex.nNonce;
+        pindexNew->nTime = diskindex.nTime;
+        pindexNew->nBits = diskindex.nBits;
+        pindexNew->nNonce = diskindex.nNonce;
+        pindexNew->nStatus = diskindex.nStatus;
+        pindexNew->blockHash = blockHash;
+
+        if (fReindex)
+        {
+            if ((pindexNew->nHeight == 0) || (pindexNew->nFile != 0 && pindexNew->nBlockPos != 0))
+            {
+                pindexNew->nStatus |= BLOCK_HAVE_DATA;
+                pindexNew->RaiseValidity(BLOCK_VALID_TRANSACTIONS);
+            }
+            else
+            {
+                printf("block height = %d has no block data, nFile = %u, nBlockPost = %u\n", pindexNew->nHeight, pindexNew->nFile, pindexNew->nBlockPos);
+            }
+        }
 
         uint256 tmpBlockhash;
         if (fStoreBlockHashToDb && !ReadBlockHash(diskindex.nFile, diskindex.nBlockPos, tmpBlockhash))
@@ -578,46 +602,30 @@ bool CTxDB::LoadBlockIndex()
             alreadyStoredBlock++;
         }
 
-        if (pindexNew->nHeight >= bestEpochIntervalHeight &&
-            ((pindexNew->nHeight % nEpochInterval == 0) || (pindexNew->nHeight == nMainnetNewLogicBlockNumber)))
-        {
-            bestEpochIntervalHeight = pindexNew->nHeight;
-            bestEpochIntervalHash = blockHash;
-        }
-        // Find the minimum ease (highest difficulty) when starting node
-        // It will be used to calculate min difficulty (maximum ease)
-        if ((pindexNew->nHeight >= nMainnetNewLogicBlockNumber) && (nMinEase > pindexNew->nBits))
-        {
-            nMinEase = pindexNew->nBits;
-        }
-
 #ifdef WIN32
-        n64timeStart11 = GetTimeMillis(); 
+        n64timeStart11 = GetTimeMillis();
         nDelta11 += (n64timeStart11 - n64timeStart10);
 
         n64deltaT += n64timeStart11 - n64timeStart;
 #endif
         // Watch for genesis block
-        if( 
+        if (
             (0 == diskindex.nHeight) &&
-            (NULL != pindexGenesisBlock)
-           )
+            (NULL != chainActive.Genesis()))
         {
             if (fPrintToConsole)
-                (void)printf( 
-                        "Error? an extra null block???"
-                        "\n"
-                        ""
-                            );
+                (void)printf(
+                    "Error? an extra null block???"
+                    "\n"
+                    "");
         }
         if (
-            (0 == diskindex.nHeight) &&     // ought to be faster than a hash check!?
-            (NULL == pindexGenesisBlock)
-           )
+            (0 == diskindex.nHeight) && // ought to be faster than a hash check!?
+            (NULL == chainActive.Genesis()))
         {
-            if (blockHash == (!fTestNet ? hashGenesisBlock : hashGenesisBlockTestNet))// check anyway, but only if block 0
+            if (blockHash == (!fTestNet ? hashGenesisBlock : hashGenesisBlockTestNet)) // check anyway, but only if block 0
             {
-                pindexGenesisBlock = pindexNew;
+                chainActive.SetTip(pindexNew);
                 /*************
 #ifdef WIN32
                 if (fPrintToConsole)
@@ -633,27 +641,24 @@ bool CTxDB::LoadBlockIndex()
             else
             {
                 if (fPrintToConsole)
-                    (void)printf( 
-                            "Error? a extra genesis block with the wrong hash???"
-                            "\n"
-                            ""
-                                );
+                    (void)printf(
+                        "Error? a extra genesis block with the wrong hash???"
+                        "\n"
+                        "");
             }
         }
         // there seem to be 2 errant blocks?
         else
         {
-            if(
-                (NULL != pindexGenesisBlock) && 
-                (0 == diskindex.nHeight) 
-              )
+            if (
+                (NULL != chainActive.Genesis()) &&
+                (0 == diskindex.nHeight))
             {
                 if (fPrintToConsole)
-                    (void)printf( 
-                            "Error? a extra genesis null block???"
-                            "\n"
-                            ""
-                                );
+                    (void)printf(
+                        "Error? a extra genesis null block???"
+                        "\n"
+                        "");
             }
         }
         //if (!pindexNew->CheckIndex()) // as it stands, this never fails??? So why bother?????
@@ -662,29 +667,25 @@ bool CTxDB::LoadBlockIndex()
         //    return error("LoadBlockIndex() : CheckIndex failed at %d", pindexNew->nHeight);
         //}
 
-        // NovaCoin: build setStakeSeen
-        if (pindexNew->IsProofOfStake())
-            setStakeSeen.insert(make_pair(pindexNew->prevoutStake, pindexNew->nStakeTime));
 #ifdef WIN32
         ++nCounter;
         // could "guess at the max nHeight & %age against the loop count
-        // to "hone in on" the %age done.  
+        // to "hone in on" the %age done.
         // Towards the end it ought to be pretty accurate.
-        if( nMaxHeightGuess < pindexNew->nHeight )
+        if (nMaxHeightGuess < pindexNew->nHeight)
         {
             nMaxHeightGuess = pindexNew->nHeight;
         }
-        if( 0 == ( nCounter % nRefresh ) )  // every nRefresh-th time through the loop
+        if (0 == (nCounter % nRefresh)) // every nRefresh-th time through the loop
         {
-            float                   // these #s are just to slosh the . around
-                dEstimate = float( ( 100.0 * nCounter ) / nMaxHeightGuess );
-            std::string 
+            float // these #s are just to slosh the . around
+                dEstimate = float((100.0 * nCounter) / nMaxHeightGuess);
+            std::string
                 sGutsNoise = strprintf(
-                            "%7d (%3.2f%%)"
-                            "",
-                            nCounter, //pindexNew->nHeight,
-                            dEstimate >= 100.0? 100.0: dEstimate
-                                      );
+                    "%7d (%3.2f%%)"
+                    "",
+                    nCounter, //pindexNew->nHeight,
+                    dEstimate >= 100.0 ? 100.0 : dEstimate);
             if (fPrintToConsole)
             {
                 /****************
@@ -695,109 +696,171 @@ bool CTxDB::LoadBlockIndex()
                             sGutsNoise.c_str()
                             );
                 ****************/
-                DoProgress( nCounter, nMaxHeightGuess, n64MsStartTime );
-                //(void)printf( 
+                DoProgress(nCounter, nMaxHeightGuess, n64MsStartTime);
+                //(void)printf(
                 //            "\r"
                 //            );
             }
-    #ifdef QT_GUI
-        //    uiInterface.InitMessage( sGutsNoise.c_str() );
-    #endif
+#ifdef QT_GUI
+            //    uiInterface.InitMessage( sGutsNoise.c_str() );
+#endif
         }
 #endif
         iterator->Next();
     }
     delete iterator;
 
-    printf("CTxDB::LoadBlockIndex(), fStoreBlockHashToDb = %d, "
-            "newStoredBlock = %d, "
-            "alreadyStoredBlock = %d\n",
-            fStoreBlockHashToDb,
-            newStoredBlock,
-            alreadyStoredBlock);
-    // Calculate current block reward
-    map<uint256, CBlockIndex*>::iterator mi = mapBlockIndex.find(bestEpochIntervalHash);
-    if (mi != mapBlockIndex.end())
+    // Load hashBestChain pointer to end of best chain
+    if (!ReadHashBestChain(hashBestChain))
     {
-        CBlockIndex* pBestEpochIntervalIndex = (*mi).second;
-        nBlockRewardPrev =
-            (::int64_t)((pBestEpochIntervalIndex->pprev ? pBestEpochIntervalIndex->pprev->nMoneySupply : pBestEpochIntervalIndex->nMoneySupply) /
-                        nNumberOfBlocksPerYear) * nInflation;
+        if (chainActive.Genesis() == NULL)
+            return true;
+        return error("CTxDB::LoadBlockIndex() : hashBestChain not loaded");
+    }
+    if (!mapBlockIndex.count(hashBestChain))
+        return error("CTxDB::LoadBlockIndex() : hashBestChain not found in the block index");
+    chainActive.SetTip(mapBlockIndex[hashBestChain]);
+
+    // Recalculate block reward and minimum ease (highest difficulty) when starting node
+    CBlockIndex* tmpBlockIndex = chainActive[nMainnetNewLogicBlockNumber];
+    while (tmpBlockIndex != NULL)
+    {
+        if (tmpBlockIndex->nHeight >= bestEpochIntervalHeight &&
+            ((tmpBlockIndex->nHeight % nEpochInterval == 0) || (tmpBlockIndex->nHeight == nMainnetNewLogicBlockNumber)))
+        {
+            bestEpochIntervalHeight = tmpBlockIndex->nHeight;
+            bestEpochIntervalHash = tmpBlockIndex->blockHash;
+        }
+        // Find the minimum ease (highest difficulty) when starting node
+        // It will be used to calculate min difficulty (maximum ease)
+        if ((tmpBlockIndex->nHeight >= nMainnetNewLogicBlockNumber) && (nMinEase > tmpBlockIndex->nBits))
+        {
+            nMinEase = tmpBlockIndex->nBits;
+        }
+        tmpBlockIndex = tmpBlockIndex->pnext;
+    }
+    // Calculate maximum target of all blocks, it corresponds to 1/3 highest difficulty (or 3 minimum ease)
+    uint256 bnMaximum = CBigNum().SetCompact(nMinEase).getuint256();
+    CBigNum bnMaximumTarget;
+    bnMaximumTarget.setuint256(bnMaximum);
+    bnMaximumTarget *= 3;
+
+    (void)printf(
+                 "Minimum difficulty target %s\n"
+                 ""
+                 , CBigNum( bnMaximumTarget ).getuint256().ToString().substr(0,16).c_str()
+                );
+
+    if (fReindex)
+    {
+        fReindex = false;
+        CBlockIndex* chainTip = chainActive.Tip();
+        while (chainTip != NULL)
+        {
+            chainTip->RaiseValidity(BLOCK_VALID_SCRIPTS);
+            chainTip = chainTip->pprev;
+        }
+
+        map<uint256, CBlockIndex *>::iterator it;
+        int numberOfReindexBlock = 0;
+        for (it = mapBlockIndex.begin(); it != mapBlockIndex.end(); it++)
+        {
+            CBlockIndex* pindexCurrent = (*it).second;
+            WriteBlockIndex(CDiskBlockIndex(pindexCurrent));
+            mapHash.insert(make_pair(pindexCurrent->GetSHA256Hash(), (*it).first));
+            numberOfReindexBlock++;
+        }
+        printf("CTxDB::LoadBlockIndex(), fReindex = 1, "
+               "numberOfReindexBlock = %d\n",
+               fReindex,
+               numberOfReindexBlock);
+
     }
     else
     {
-       printf("There is something wrong, can't find best epoch interval block\n");
+        map<uint256, CBlockIndex *>::iterator it;
+        for (it = mapBlockIndex.begin(); it != mapBlockIndex.end(); it++)
+        {
+            CBlockIndex* pindexCurrent = (*it).second;
+            mapHash.insert(make_pair(pindexCurrent->GetSHA256Hash(), (*it).first)).first;
+        }
     }
 
+    printf("CTxDB::LoadBlockIndex(), fStoreBlockHashToDb = %d, "
+           "newStoredBlock = %d, "
+           "alreadyStoredBlock = %d\n",
+           fStoreBlockHashToDb,
+           newStoredBlock,
+           alreadyStoredBlock);
+    // Calculate current block reward
+    map<uint256, CBlockIndex *>::iterator mi = mapBlockIndex.find(bestEpochIntervalHash);
+    if (mi != mapBlockIndex.end())
+    {
+        CBlockIndex *pBestEpochIntervalIndex = (*mi).second;
+        nBlockRewardPrev =
+            (::int64_t)((pBestEpochIntervalIndex->pprev ? pBestEpochIntervalIndex->pprev->nMoneySupply : pBestEpochIntervalIndex->nMoneySupply) /
+                        nNumberOfBlocksPerYear) *
+            nInflation;
+    }
+    else
+    {
+        printf("There is something wrong, can't find best epoch interval block\n");
+    }
 
     if (fRequestShutdown)
         return true;
 #ifdef WIN32
     if (fPrintToConsole)
     {
-        DoProgress( nCounter, nCounter, n64MsStartTime );
-        (void)printf( "\n" );
+        DoProgress(nCounter, nCounter, n64MsStartTime);
+        (void)printf("\n");
     }
-    #ifdef QT_GUI
+#ifdef QT_GUI
     uiInterface.InitMessage(_("<b>...done.</b>"));
-    #endif
+#endif
 #endif
 
 #ifdef WIN32
-    if (fPrintToConsole) 
+    if (fPrintToConsole)
     {
         (void)printf(
             "delta times"
-            "\n1 %" 
-            PRId64 
-            "\n2 %" 
-            PRId64 
-            "\n3 %" 
-            PRId64 
-            "\n4 %" 
-            PRId64 
-            "\n5 %" 
-            PRId64 
-            "\n6 %" 
-            PRId64 
-            "\n7 %" 
-            PRId64  
-            "\n8 %" 
-            PRId64 
-            "\n9 %" 
-            PRId64 
-            "\n10 %" 
-            PRId64 
-            "\n11 %" 
-            PRId64 
-            "\nt %" 
-            PRId64 
+            "\n1 %" PRId64
+            "\n2 %" PRId64
+            "\n3 %" PRId64
+            "\n4 %" PRId64
+            "\n5 %" PRId64
+            "\n6 %" PRId64
+            "\n7 %" PRId64
+            "\n8 %" PRId64
+            "\n9 %" PRId64
+            "\n10 %" PRId64
+            "\n11 %" PRId64
+            "\nt %" PRId64
             "\n",
-        nDelta1,
-        nDelta2,
-        nDelta3,
-        nDelta4,
-        nDelta5,
-        nDelta6,
-        nDelta7,
-        nDelta8,
-        nDelta9,
-        nDelta10,
-        nDelta11,
-        n64deltaT 
-                   );
+            nDelta1,
+            nDelta2,
+            nDelta3,
+            nDelta4,
+            nDelta5,
+            nDelta6,
+            nDelta7,
+            nDelta8,
+            nDelta9,
+            nDelta10,
+            nDelta11,
+            n64deltaT);
     }
 #endif
-// <<<<<<<<<
+    // <<<<<<<<<
 
 #ifdef WIN32
-    if (fPrintToConsole) 
-        (void)printf( "Sorting by height..." );        
-    #ifdef QT_GUI
+    if (fPrintToConsole)
+        (void)printf("Sorting by height...");
+#ifdef QT_GUI
     uiInterface.InitMessage(
-                            _("Sorting by height...")
-                           );
-    #endif
+        _("Sorting by height..."));
+#endif
     nCounter = 0;
 #endif
     // Calculate bnChainTrust
@@ -811,121 +874,124 @@ bool CTxDB::LoadBlockIndex()
 
         int
             nUpdatePeriod = 10000;
-        BOOST_FOREACH(const PAIRTYPE(uint256, CBlockIndex*)& item, mapBlockIndex)
+        BOOST_FOREACH (const PAIRTYPE(uint256, CBlockIndex *) & item, mapBlockIndex)
         {
             CBlockIndex
-                * pindex = item.second;
+                *pindex = item.second;
 
             vSortedByHeight.push_back(make_pair(pindex->nHeight, pindex));
 #ifdef WIN32
             ++nCounter;
-            if( 0 == (nCounter % nUpdatePeriod) )
+            if (0 == (nCounter % nUpdatePeriod))
             {
-    #ifdef QT_GUI
-                uiInterface.InitMessage( strprintf( _("%7d"), nCounter ) );
-    #else
-                if (fPrintToConsole) 
-                    printf( "%7d\r", nCounter );
-    #endif
+#ifdef QT_GUI
+                uiInterface.InitMessage(strprintf(_("%7d"), nCounter));
+#else
+                if (fPrintToConsole)
+                    printf("%7d\r", nCounter);
+#endif
             }
-#endif        
+#endif
         }
         sort(vSortedByHeight.begin(), vSortedByHeight.end());
 #ifdef WIN32
-        if (fPrintToConsole) 
-            (void)printf( "\ndone\nChecking stake checksums...\n" );
-    #ifdef _DEBUG
+        if (fPrintToConsole)
+            (void)printf("\ndone\nChecking stake checksums...\n");
+#ifdef _DEBUG
         nUpdatePeriod /= 20; // speed up update for debug mode
-    #else
+#else
         nUpdatePeriod /= 2; // slow down update for release mode
-    #endif
-    #ifdef QT_GUI
-        uiInterface.InitMessage( _("done") );
-        uiInterface.InitMessage( _("Checking stake checksums...") );
-    #endif
+#endif
+#ifdef QT_GUI
+        uiInterface.InitMessage(_("done"));
+        uiInterface.InitMessage(_("Checking stake checksums..."));
+#endif
         nCounter = 0;
 #endif
 
-        BOOST_FOREACH(const PAIRTYPE(int, CBlockIndex*)& item, vSortedByHeight)
+        BOOST_FOREACH (const PAIRTYPE(int, CBlockIndex *) & item, vSortedByHeight)
         {
-            CBlockIndex* pindex = item.second;
-            if (pindex->nHeight >= nMainnetNewLogicBlockNumber)
-				break;
-            pindex->nPosBlockCount = ( pindex->pprev ? pindex->pprev->nPosBlockCount : 0 ) + ( pindex->IsProofOfStake() ? 1 : 0 );
-            pindex->nBitsMA = pindex->IsProofOfStake() ? GetProofOfWorkMA(pindex->pprev) : 0;
+            CBlockIndex *pindex = item.second;
             pindex->bnChainTrust = (pindex->pprev ? pindex->pprev->bnChainTrust : CBigNum(0)) + pindex->GetBlockTrust();
             // NovaCoin: calculate stake modifier checksum
             pindex->nStakeModifierChecksum = GetStakeModifierChecksum(pindex);
             if (!CheckStakeModifierCheckpoints(pindex->nHeight, pindex->nStakeModifierChecksum))
-                return error("CTxDB::LoadBlockIndex() : Failed stake modifier checkpoint height=%d, modifier=0x%016" PRIx64, pindex->nHeight, pindex->nStakeModifier);
+                printf("CTxDB::LoadBlockIndex() : Failed stake modifier checkpoint height=%d, modifier=0x%016\n" PRIx64, pindex->nHeight, pindex->nStakeModifier);
+            if (pindex->nStatus & BLOCK_HAVE_DATA) {
+                if (pindex->pprev) {
+                    if (pindex->pprev->validTx) {
+                        pindex->validTx = true;
+                    } else {
+                        pindex->validTx = false;
+                        mapBlocksUnlinked.insert(std::make_pair(pindex->pprev, pindex));
+                    }
+                } else {
+                    pindex->validTx = true;
+                }
+            }
+            if (pindex->IsValid(BLOCK_VALID_TRANSACTIONS) && (pindex->validTx || pindex->pprev == NULL))
+                setBlockIndexCandidates.insert(pindex);
+            if (pindex->nStatus & BLOCK_FAILED_MASK && (!pindexBestInvalid || pindex->bnChainTrust > pindexBestInvalid->bnChainTrust))
+                pindexBestInvalid = pindex;
+            if (pindex->pprev)
+                pindex->BuildSkip();
+            if (pindex->IsValid(BLOCK_VALID_TREE) && (pindexBestHeader == NULL || CBlockIndexWorkComparator()(pindexBestHeader, pindex)))
+                pindexBestHeader = pindex;
 #ifdef WIN32
             ++nCounter;
-            if( 0 == (nCounter % nUpdatePeriod) )
+            if (0 == (nCounter % nUpdatePeriod))
             {
-    #ifdef QT_GUI
-                uiInterface.InitMessage( strprintf( _("%7d"), nCounter ) );
-    #else
-                if (fPrintToConsole) 
-                    printf( "%7d\r", nCounter );
-    #endif
+#ifdef QT_GUI
+                uiInterface.InitMessage(strprintf(_("%7d"), nCounter));
+#else
+                if (fPrintToConsole)
+                    printf("%7d\r", nCounter);
+#endif
             }
-#endif        
+#endif
         }
     }
 
 #ifdef WIN32
-    if (fPrintToConsole) 
-        (void)printf( "\ndone\n"
-                      "Read best chain\n" 
-                    );        
-    #ifdef QT_GUI
-    uiInterface.InitMessage( _("...done") );
-    uiInterface.InitMessage( _("Read best chain") );
-    #endif
-#endif        
+    if (fPrintToConsole)
+        (void)printf("\ndone\n"
+                     "Read best chain\n");
+#ifdef QT_GUI
+    uiInterface.InitMessage(_("...done"));
+    uiInterface.InitMessage(_("Read best chain"));
+#endif
+#endif
 
-    // Load hashBestChain pointer to end of best chain
-    if (!ReadHashBestChain(hashBestChain))
-    {
-        if (pindexGenesisBlock == NULL)
-            return true;
-        return error("CTxDB::LoadBlockIndex() : hashBestChain not loaded");
-    }
-    if (!mapBlockIndex.count(hashBestChain))
-        return error("CTxDB::LoadBlockIndex() : hashBestChain not found in the block index");
-    pindexBest = mapBlockIndex[hashBestChain];
-    nBestHeight = pindexBest->nHeight;
-    bnBestChainTrust = pindexBest->bnChainTrust;
+    bnBestChainTrust = chainActive.Tip()->bnChainTrust;
 
     printf("LoadBlockIndex(): hashBestChain=%s  height=%d  trust=%s  date=%s\n",
-      hashBestChain.ToString().substr(0,20).c_str(), nBestHeight, bnBestChainTrust.ToString().c_str(),
-      DateTimeStrFormat("%x %H:%M:%S", pindexBest->GetBlockTime()).c_str());
+           hashBestChain.ToString().substr(0, 20).c_str(), chainActive.Height(), bnBestChainTrust.ToString().c_str(),
+           DateTimeStrFormat("%x %H:%M:%S", chainActive.Tip()->GetBlockTime()).c_str());
 
     // NovaCoin: load hashSyncCheckpoint
-    if( !fTestNet )
+    if (!fTestNet)
     {
         if (!ReadSyncCheckpoint(Checkpoints::hashSyncCheckpoint))
             return error("CTxDB::LoadBlockIndex() : hashSyncCheckpoint not loaded");
-        printf("LoadBlockIndex(): synchronized checkpoint %s\n", 
-               Checkpoints::hashSyncCheckpoint.ToString().c_str()
-              );
+        printf("LoadBlockIndex(): synchronized checkpoint %s\n",
+               Checkpoints::hashSyncCheckpoint.ToString().c_str());
     }
     // Load bnBestInvalidTrust, OK if it doesn't exist
-    ReadBestInvalidTrust(bnBestInvalidTrust);
+    //    ReadBestInvalidTrust(bnBestInvalidTrust);
 
     // Verify blocks in the best chain
     int nCheckLevel = GetArg("-checklevel", 1);
-    int nCheckDepth = GetArg( "-checkblocks", 750);
+    int nCheckDepth = GetArg("-checkblocks", 750);
     if (nCheckDepth == 0)
         nCheckDepth = 1000000000; // suffices until the year 19000
-    if (nCheckDepth > nBestHeight)
-        nCheckDepth = nBestHeight;
+    if (nCheckDepth > chainActive.Height())
+        nCheckDepth = chainActive.Height();
 
 #ifdef WIN32
     nCounter = 0;
     //#ifdef _MSC_VER
-        #ifdef _DEBUG
-        /****************
+#ifdef _DEBUG
+/****************
         const int
             nMINUTESperBLOCK = 1,   // or whatever you want to do in this *coin
             nMINUTESperHOUR = 60,
@@ -935,48 +1001,48 @@ bool CTxDB::LoadBlockIndex()
 
         nCheckDepth = nBLOCKSinLASTwhateverHOURS;
         ****************/
-        #endif
-    //#endif
-    #ifdef QT_GUI
+#endif
+//#endif
+#ifdef QT_GUI
     std::string
         sX;
     uiInterface.InitMessage(
-                            strprintf( _("Verifying the last %i blocks at level %i"), 
-                                        nCheckDepth, nCheckLevel
-                                     ).c_str()
-                           );
-    #endif
+        strprintf(_("Verifying the last %i blocks at level %i"),
+                  nCheckDepth, nCheckLevel)
+            .c_str());
+#endif
 #endif
     printf("Verifying last %i blocks at level %i\n", nCheckDepth, nCheckLevel);
-    CBlockIndex* pindexFork = NULL;
-    map<pair<unsigned int, unsigned int>, CBlockIndex*> mapBlockPos;
-    for (CBlockIndex* pindex = pindexBest; pindex && pindex->pprev; pindex = pindex->pprev)
+    CBlockIndex *pindexFork = NULL;
+    map<pair<unsigned int, unsigned int>, CBlockIndex *> mapBlockPos;
+    for (CBlockIndex *pindex = chainActive.Tip(); pindex && pindex->pprev; pindex = pindex->pprev)
     {
-        if (fRequestShutdown || pindex->nHeight < nBestHeight-nCheckDepth)
+        if (fRequestShutdown || pindex->nHeight < chainActive.Height() - nCheckDepth)
             break;
         CBlock block;
+        CValidationState stateDummy;
         if (!block.ReadFromDisk(pindex))
             return error("LoadBlockIndex() : block.ReadFromDisk failed");
         // check level 1: verify block validity
         // check level 7: verify block signature too
-        if (nCheckLevel>0 && !block.CheckBlock(true, true, (nCheckLevel>6)))
+        if (nCheckLevel > 0 && !block.CheckBlock(stateDummy, true, true, (nCheckLevel > 6)))
         {
             printf("LoadBlockIndex() : *** found bad block at %d, hash=%s\n", pindex->nHeight, pindex->GetBlockHash().ToString().c_str());
             pindexFork = pindex->pprev;
         }
         // check level 2: verify transaction index validity
-        if (nCheckLevel>1)
+        if (nCheckLevel > 1)
         {
             pair<unsigned int, unsigned int> pos = make_pair(pindex->nFile, pindex->nBlockPos);
             mapBlockPos[pos] = pindex;
-            BOOST_FOREACH(const CTransaction &tx, block.vtx)
+            BOOST_FOREACH (const CTransaction &tx, block.vtx)
             {
                 uint256 hashTx = tx.GetHash();
                 CTxIndex txindex;
                 if (ReadTxIndex(hashTx, txindex))
                 {
                     // check level 3: checker transaction hashes
-                    if (nCheckLevel>2 || pindex->nFile != txindex.pos.Get_CDiskTxPos_nFile() || pindex->nBlockPos != txindex.pos.Get_CDiskTxPos_nBlockPos())
+                    if (nCheckLevel > 2 || pindex->nFile != txindex.pos.Get_CDiskTxPos_nFile() || pindex->nBlockPos != txindex.pos.Get_CDiskTxPos_nBlockPos())
                     {
                         // either an error or a duplicate transaction
                         CTransaction txFound;
@@ -985,19 +1051,18 @@ bool CTxDB::LoadBlockIndex()
                             printf("LoadBlockIndex() : *** cannot read mislocated transaction %s\n", hashTx.ToString().c_str());
                             pindexFork = pindex->pprev;
                         }
-                        else
-                            if (txFound.GetHash() != hashTx) // not a duplicate tx
-                            {
-                                printf("LoadBlockIndex(): *** invalid tx position for %s\n", hashTx.ToString().c_str());
-                                pindexFork = pindex->pprev;
-                            }
+                        else if (txFound.GetHash() != hashTx) // not a duplicate tx
+                        {
+                            printf("LoadBlockIndex(): *** invalid tx position for %s\n", hashTx.ToString().c_str());
+                            pindexFork = pindex->pprev;
+                        }
                     }
                     // check level 4: check whether spent txouts were spent within the main chain
-                    unsigned int 
+                    unsigned int
                         nOutput = 0;
-                    if (nCheckLevel>3)
+                    if (nCheckLevel > 3)
                     {
-                        BOOST_FOREACH(const CDiskTxPos &txpos, txindex.vSpent)
+                        BOOST_FOREACH (const CDiskTxPos &txpos, txindex.vSpent)
                         {
                             if (!txpos.IsNull())
                             {
@@ -1008,7 +1073,7 @@ bool CTxDB::LoadBlockIndex()
                                     pindexFork = pindex->pprev;
                                 }
                                 // check level 6: check whether spent txouts were spent by a valid transaction that consume them
-                                if (nCheckLevel>5)
+                                if (nCheckLevel > 5)
                                 {
                                     CTransaction txSpend;
                                     if (!txSpend.ReadFromDisk(txpos))
@@ -1016,7 +1081,7 @@ bool CTxDB::LoadBlockIndex()
                                         printf("LoadBlockIndex(): *** cannot read spending transaction of %s:%i from disk\n", hashTx.ToString().c_str(), nOutput);
                                         pindexFork = pindex->pprev;
                                     }
-                                    else if (!txSpend.CheckTransaction())
+                                    else if (!txSpend.CheckTransaction(stateDummy))
                                     {
                                         printf("LoadBlockIndex(): *** spending transaction of %s:%i is invalid\n", hashTx.ToString().c_str(), nOutput);
                                         pindexFork = pindex->pprev;
@@ -1024,7 +1089,7 @@ bool CTxDB::LoadBlockIndex()
                                     else
                                     {
                                         bool fFound = false;
-                                        BOOST_FOREACH(const CTxIn &txin, txSpend.vin)
+                                        BOOST_FOREACH (const CTxIn &txin, txSpend.vin)
                                             if (txin.prevout.COutPointGetHash() == hashTx && txin.prevout.COutPointGet_n() == nOutput)
                                                 fFound = true;
                                         if (!fFound)
@@ -1040,44 +1105,42 @@ bool CTxDB::LoadBlockIndex()
                     }
                 }
                 // check level 5: check whether all prevouts are marked spent
-                if (nCheckLevel>4)
+                if (nCheckLevel > 4)
                 {
-                     BOOST_FOREACH(const CTxIn &txin, tx.vin)
-                     {
-                          CTxIndex txindex;
-                          if (ReadTxIndex(txin.prevout.COutPointGetHash(), txindex))
-                              if (txindex.vSpent.size()-1 < txin.prevout.COutPointGet_n() || txindex.vSpent[txin.prevout.COutPointGet_n()].IsNull())
-                              {
-                                  printf("LoadBlockIndex(): *** found unspent prevout %s:%i in %s\n", txin.prevout.COutPointGetHash().ToString().c_str(), txin.prevout.COutPointGet_n(), hashTx.ToString().c_str());
-                                  pindexFork = pindex->pprev;
-                              }
-                     }
+                    BOOST_FOREACH (const CTxIn &txin, tx.vin)
+                    {
+                        CTxIndex txindex;
+                        if (ReadTxIndex(txin.prevout.COutPointGetHash(), txindex))
+                            if (txindex.vSpent.size() - 1 < txin.prevout.COutPointGet_n() || txindex.vSpent[txin.prevout.COutPointGet_n()].IsNull())
+                            {
+                                printf("LoadBlockIndex(): *** found unspent prevout %s:%i in %s\n", txin.prevout.COutPointGetHash().ToString().c_str(), txin.prevout.COutPointGet_n(), hashTx.ToString().c_str());
+                                pindexFork = pindex->pprev;
+                            }
+                    }
                 }
             }
         }
 #ifdef WIN32
-    #ifdef _MSC_VER
-        if (fPrintToConsole) 
+#ifdef _MSC_VER
+        if (fPrintToConsole)
         {
-            (void)printf( "\b\b\b" );       // , 1
-         // (void)printf( "Verifying %7d at 0",
-            (void)printf(// V e r i f y i n g   n n n n n n n   a t   t
-                          "\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b"
-                        );
+            (void)printf("\b\b\b"); // , 1
+                                    // (void)printf( "Verifying %7d at 0",
+            (void)printf(           // V e r i f y i n g   n n n n n n n   a t   t
+                "\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b");
         }
-    #endif        
-        ++nCounter;                
-#endif        
+#endif
+        ++nCounter;
+#endif
 #ifdef WIN32
-    #ifdef _MSC_VER
-        if (fPrintToConsole) 
-            (void)printf( "Verifying %7d",
-                          nCheckDepth - nCounter  
-                        );        
-    #endif        
-    #ifdef QT_GUI
-        uiInterface.InitMessage( strprintf( "Verifying %7d", nCheckDepth - nCounter ).c_str() );
-    #endif
+#ifdef _MSC_VER
+        if (fPrintToConsole)
+            (void)printf("Verifying %7d",
+                         nCheckDepth - nCounter);
+#endif
+#ifdef QT_GUI
+        uiInterface.InitMessage(strprintf("Verifying %7d", nCheckDepth - nCounter).c_str());
+#endif
 #endif
     }
     if (pindexFork && !fRequestShutdown)
@@ -1087,13 +1150,14 @@ bool CTxDB::LoadBlockIndex()
         CBlock block;
         if (!block.ReadFromDisk(pindexFork))
             return error("LoadBlockIndex() : block.ReadFromDisk failed");
+        setBlockIndexCandidates.insert(pindexFork);
         CTxDB txdb;
-        block.SetBestChain(txdb, pindexFork);
+        CValidationState state;
+        ActivateBestChain(state, txdb);
     }
 
     return true;
 }
 #ifdef _MSC_VER
-    #include "msvc_warnings.pop.h"
-#endif
+#include "msvc_warnings.pop.h"
 #endif

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -94,6 +94,7 @@ bool fTestNetNewLogic = false;
 ::int32_t nMainnetNewLogicBlockNumber;
 unsigned char MAXIMUM_YAC1DOT0_N_FACTOR;
 ::int32_t nYac20BlockNumberTime = 0;
+::int64_t nYac10HardforkTime = 1619048730;
 // Epoch interval is a difficulty period. Right now on testnet, it is 21,000 blocks
 ::uint32_t nEpochInterval = 21000;
 ::uint32_t nDifficultyInterval = nEpochInterval;

--- a/src/util.h
+++ b/src/util.h
@@ -192,6 +192,8 @@ extern ::int32_t
 extern ::uint32_t
     nDifficultyInterval,
     nEpochInterval;
+extern ::int64_t
+    nYac10HardforkTime;
 extern std::string strMiscWarning;
 extern unsigned char MAXIMUM_YAC1DOT0_N_FACTOR;
 
@@ -396,6 +398,12 @@ inline ::int64_t GetTimeMillis()
 {
     return (boost::posix_time::ptime(boost::posix_time::microsec_clock::universal_time()) -
             boost::posix_time::ptime(boost::gregorian::date(1970,1,1))).total_milliseconds();
+}
+
+inline int64_t GetTimeMicros()
+{
+    return (boost::posix_time::ptime(boost::posix_time::microsec_clock::universal_time()) -
+            boost::posix_time::ptime(boost::gregorian::date(1970,1,1))).total_microseconds();
 }
 
 inline std::string DateTimeStrFormat(const char* pszFormat, ::int64_t nTime)

--- a/src/version.h
+++ b/src/version.h
@@ -45,6 +45,12 @@ static const int PROTOCOL_VERSION = 60009;
 // earlier versions not supported as of Feb 2012, and are disconnected
 static const int MIN_PROTO_VERSION = 209;
 
+// In this version, 'getheaders' was introduced.
+static const int GETHEADERS_VERSION = 31800;
+
+// disconnect from peers older than this proto version
+static const int MIN_PEER_PROTO_VERSION = GETHEADERS_VERSION;
+
 // disconnect buggy clients
 static const int MIN_PEER_BUGGY_VERSION = 60006;
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1298,7 +1298,7 @@ void CWallet::ReacceptWalletTransactions()
         if (!vMissingTx.empty())
         {
             // TODO: optimize this to scan just part of the block chain?
-            if (ScanForWalletTransactions(pindexGenesisBlock))
+            if (ScanForWalletTransactions(chainActive.Genesis()))
                 fRepeat = true;  // Found missing transactions: re-do re-accept.
         }
     }
@@ -1377,7 +1377,8 @@ void CWallet::ResendWalletTransactions()
         BOOST_FOREACH(PAIRTYPE(const unsigned int, CWalletTx*)& item, mapSorted)
         {
             CWalletTx& wtx = *item.second;
-            if (wtx.CheckTransaction())
+            CValidationState state;
+            if (wtx.CheckTransaction(state))
                 wtx.RelayWalletTransaction(txdb);
             else
                 printf("ResendWalletTransactions() : CheckTransaction failed for transaction %s\n", wtx.GetHash().ToString().c_str());
@@ -2259,7 +2260,7 @@ bool CWallet::CreateCoinStake(
     // Keep combining coins until 10 times POW reward is reached.
     // Really!  That's news to me.
     ::int64_t
-        nCombineThreshold = GetProofOfWorkReward(GetLastBlockIndex(pindexBest, false)->nBits) * 10;
+        nCombineThreshold = GetProofOfWorkReward(GetLastBlockIndex(chainActive.Tip(), false)->nBits) * 10;
     // Minimum age for coins that will be combined.
     unsigned int 
         nStakeCombineAge = fTestNet? nStakeMinAge: nOneDayInSeconds * 31;   // in seconds??
@@ -3561,8 +3562,8 @@ void CWallet::GetKeyBirthTimes(std::map<CKeyID, int64_t> &mapKeyBirth) const
     }
     // map in which we'll infer heights of other keys
     CBlockIndex                                 // if this is one day in btc? then what for yac??
-      //*pindexMax = FindBlockByHeight(std::max(0, nBestHeight - 144)); // the tip can be reorganised; use a 144-block safety margin
-        *pindexMax = FindBlockByHeight(std::max(0, nBestHeight
+      //*pindexMax = FindBlockByHeight(std::max(0, chainActive.Height() - 144)); // the tip can be reorganised; use a 144-block safety margin
+        *pindexMax = FindBlockByHeight(std::max(0, chainActive.Height()
          - (int)nOnedayOfAverageBlocks)); // the tip can be reorganised; use a 144-block safety margin
 
     std::map<CKeyID, CBlockIndex*> mapKeyFirstBlock;


### PR DESCRIPTION
* Add debug log

* Replace pindexBest, pindexGenesisBlock, nBestHeight with chainActive

* Replace bnBestInvalidTrust with pindexBestInvalid

* Clang-format txdb-leveldb.cpp

* Add the missing logic: bnChainTrust is calculated at the startup

* Add setBlockIndexValid, BlockStatus enum, and new flag nStatus for
CBlockIndex

* Use setBlockIndexValid and new flag nStatus for CBlockIndex

* Add ConnectBestBlock()

* Refactor SetBestChain and Reorganize logic

* Add CValidationState

* Move only: extract WriteChainState and UpdatedTip from SetBestChain.

* Prepare block connection logic for headers-first

* Remove redundant code

* Reindex for old database

* clang format network logic

* Make sure we always have a node to do IBD from

This introduces the concept of the 'sync node', which is the one we
asked for missing blocks. In case the sync node goes away, a new one
will be selected.

For now, the heuristic is very simple, but it can easily be extended
later to add better policies.

* Add main-specific node state & move ban score

* Per-peer block download tracking and stalled download detection.

* Split off CBlockHeader from CBlock

* Split up CheckBlock in a block and header version

* Split AcceptBlockHeader from AcceptBlock

* Allow SendMessages to run partially without cs_main

* Get rid of the static chainMostWork (optimization)

* Allow ActivateBestChain to release its lock on cs_main

* Move all post-chaintip-change notifications to ActivateBestChain

* Push cs_mains down in ProcessBlock

* Add missing LOCK(cs_main)

* fixup! Move all post-chaintip-change notifications to ActivateBestChain

* Track peers' available blocks

* Add a skiplist to the CBlockIndex structure.

* Replace FindBlockByHeight with chainActive height

* Replace CBlockLocator with chainActive.GetLocator

* Correct "detect stalled peers" logic

* Headers-first synchronization

* RPC additions after headers-first

* Remove checks to prevent "fill up memory by spamming with bogus blocks", as we always know all parent headers

* Better logging

* Improve performance of ActivateBestChainStep

Improve the performance of ActivateBestBlockStep by using the skiplist to only discover
a few potential blocks to connect at a time, instead of all blocks forever - as we likely bail
out after connecting a single one anyway.

* Fix large reorgs

* Avoid calculating hash many times at initial-block-sync

* Remove redundant debug log

* Fix CChain::GetLocator

* Only keep setBlockIndexValid entries that are possible improvements

* Not return error when Rejected by stake modifier checkpoint

* Fix issue which update wrong block index in ReceivedBlockTransactions

* Avoid sending "getheaders" when receive "inv" during IBD

* fixup! Avoid calculating hash many times at initial-block-sync

* fixup! fixup! Avoid calculating hash many times at initial-block-sync

* fixup! Not return error when Rejected by stake modifier checkpoint

* Add extra checkpoints

* Various improvement for initial-block-sync

* Timeout for headers sync

* Not download block from initial-header-sync node, unless best header close to today

* Trigger sending "getblocks" to other peers when enough headers

Trigger sending "getblocks" to other peers when
1) bestHeaderHeight > bestBlockHeight + HEADER_BLOCK_DIFFERENCES_TRIGGER_GETDATA (default = 400000)
2) synced_headers < bestHeaderHeight

* Reindex for old database (part 2)

* Fix issue which failed to accept hardfork block

* Correct the logic which recalculate block reward and minEase when starting node

* fixup! Correct the logic which recalculate block reward and minEase when starting node

* Lower the DoS score when incorrect Pow to not ban the node which have weaker-chain

* Remove redundant release time

* Add debug log when FinalizeNode

* Timeout for block sync

* Allow user to configure values relating to init-sync

* Avoid spamming getblocks, just send getblocks every 1 minute

* Add missing CheckBlockHeader in AcceptBlockHeader

* Avoid syncing headers from the peer which doesn't have latest blockchain

* Fix log

* Change getblockchaininfo to gettimechaininfo