### PR TITLE
Relax IsStandard rules for pay-to-script-hash transactions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1055,15 +1055,13 @@ bool CTransaction::IsStandard(string& strReason) const
 }
 
 //
-// Check transaction inputs, and make sure any
-// pay-to-script-hash transactions are evaluating IsStandard scripts
+// Check transaction inputs to mitigate two
+// potential denial-of-service attacks:
 //
-// Why bother? To avoid denial-of-service attacks; an attacker
-// can submit a standard HASH... OP_EQUAL transaction,
-// which will get accepted into blocks. The redemption
-// script can be anything; an attacker could use a very
-// expensive-to-check-upon-redemption script like:
-//   DUP CHECKSIG DROP ... repeated 100 times... OP_1
+// 1. scriptSigs with extra data stuffed into them,
+//    not consumed by scriptPubKey (or P2SH script)
+// 2. P2SH scripts with a crazy number of expensive
+//    CHECKSIG/CHECKMULTISIG operations
 //
 bool CTransaction::AreInputsStandard(const MapPrevTx& mapInputs) const
 {
@@ -1078,42 +1076,60 @@ bool CTransaction::AreInputsStandard(const MapPrevTx& mapInputs) const
         txnouttype whichType;
         // get the scriptPubKey corresponding to this input:
         const CScript& prevScript = prev.scriptPubKey;
+
         if (!Solver(prevScript, whichType, vSolutions))
+        {
             return false;
+        }
         int nArgsExpected = ScriptSigArgsExpected(whichType, vSolutions);
         if (nArgsExpected < 0)
+        {
             return false;
+        }
 
         // Transactions with extra stuff in their scriptSigs are
         // non-standard. Note that this EvalScript() call will
         // be quick, because if there are any operations
-        // beside "push data" in the scriptSig the
-        // IsStandard() call returns false
+        // beside "push data" in the scriptSig
+        // IsStandard() will have already returned false
+        // and this method isn't called.
         vector<vector<unsigned char> > stack;
         if (!EvalScript(stack, vin[i].scriptSig, *this, i, false, 0))
+        {
             return false;
+        }
 
         if (whichType == TX_SCRIPTHASH)
         {
             if (stack.empty())
+            {
                 return false;
+            }
             CScript subscript(stack.back().begin(), stack.back().end());
             vector<vector<unsigned char> > vSolutions2;
             txnouttype whichType2;
-            if (!Solver(subscript, whichType2, vSolutions2))
-                return false;
-            if (whichType2 == TX_SCRIPTHASH)
-                return false;
-
-            int tmpExpected;
-            tmpExpected = ScriptSigArgsExpected(whichType2, vSolutions2);
-            if (tmpExpected < 0)
-                return false;
-            nArgsExpected += tmpExpected;
+            if (Solver(subscript, whichType2, vSolutions2))
+            {
+                int tmpExpected = ScriptSigArgsExpected(whichType2, vSolutions2);
+                if (tmpExpected < 0)
+                {
+                    return false;
+                }
+                nArgsExpected += tmpExpected;
+            }
+            else
+            {
+                // Any other Script with less than 15 sigops OK:
+                unsigned int sigops = subscript.GetSigOpCount(true);
+                // ... extra data left on the stack after execution is OK, too:
+                return (sigops <= MAX_P2SH_SIGOPS);
+            }
         }
 
         if (stack.size() != (unsigned int)nArgsExpected)
+        {
             return false;
+        }
     }
 
     return true;

--- a/src/main.h
+++ b/src/main.h
@@ -64,7 +64,7 @@ static const unsigned int MAX_GENESIS_BLOCK_SIZE = 1000000;
 static const unsigned int MAX_ORPHAN_TRANSACTIONS = 10000;
 static const unsigned int MAX_INV_SZ = 50000;
 /** Maxiumum number of signature check operations in an IsStandard() P2SH script */
-static const unsigned int MAX_P2SH_SIGOPS = 15;
+static const unsigned int MAX_P2SH_SIGOPS = 21;
 
 static const ::int64_t MIN_TX_FEE = CENT;
 static const ::int64_t MIN_RELAY_TX_FEE = MIN_TX_FEE;

--- a/src/main.h
+++ b/src/main.h
@@ -63,6 +63,8 @@ extern int
 static const unsigned int MAX_GENESIS_BLOCK_SIZE = 1000000;
 static const unsigned int MAX_ORPHAN_TRANSACTIONS = 10000;
 static const unsigned int MAX_INV_SZ = 50000;
+/** Maxiumum number of signature check operations in an IsStandard() P2SH script */
+static const unsigned int MAX_P2SH_SIGOPS = 15;
 
 static const ::int64_t MIN_TX_FEE = CENT;
 static const ::int64_t MIN_RELAY_TX_FEE = MIN_TX_FEE;


### PR DESCRIPTION
Hi all,

This PR relaxes IsStandard rules to allow applications to make use of any valid script type, such as multi signature “n-of-m OR y”, or hash time lock contract used for atomic swap